### PR TITLE
[#4] Temporarily removes volumes from dev docker-compose configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,26 +4,18 @@ services:
   ml_service:
     ports:
       - 3001:3001
-    volumes:
-      - ./src/ml_service:/usr/src/app
   nlp_service:
     ports:
       - 3002:3002
-    volumes:
-      - ./src/nlp_service:/usr/src/app
   backend_service:
     ports:
       - 3003:3003
-    volumes:
-      - ./src/backend_service:/usr/src/app
   web_client:
     command: npm start
     depends_on:
       - backend_service
     ports:
       - 3039:3039
-    volumes:
-      - ./src/web_client:/usr/src/app
   postgresql_db:
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET


### PR DESCRIPTION
[#4]

- [x] Temporarily removes volumes from dev docker-compose configuration.

This was done because two services are not functional when volumes are enabled.
- `web_client` cannot write `node_modules` 
- `nlp_service` cannot write `tenant_landlord_classifier/landlord.extended.txt`

This is because the volumes don't have write permissions from the Docker container. 

I will have to investigate and come up with a solution that allows for volumes for auto-reload, but also has write permissions that work cross-platform (Windows/Mac/Linux).

Removing volumes fixes the build in the meantime.