### PR TITLE
[#15] Adds service dependencies to base docker configuration in order prevent failure when spinning up services.

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -4,21 +4,30 @@ services:
   ml_service:
     build: ./src/ml_service
     image: procezeus/ml_service
+    depends_on:
+      - postgresql_db
     networks:
       - procezeus_net
   nlp_service:
     build: ./src/nlp_service
     image: procezeus/nlp_service
+    depends_on:
+      - postgresql_db
     networks:
       - procezeus_net
   backend_service:
     build: ./src/backend_service
     image: procezeus/backend_service
+    depends_on:
+      - postgresql_db
+      - nlp_service
     networks:
       - procezeus_net
   web_client:
     build: ./src/web_client
     image: procezeus/web_client
+    depends_on:
+      - backend_service
     networks:
       - procezeus_net
   postgresql_db:

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -4,20 +4,19 @@ services:
   ml_service:
     build: ./src/ml_service
     image: procezeus/ml_service
-    depends_on:
-      - postgresql_db
+    restart: always
     networks:
       - procezeus_net
   nlp_service:
     build: ./src/nlp_service
     image: procezeus/nlp_service
-    depends_on:
-      - postgresql_db
+    restart: always
     networks:
       - procezeus_net
   backend_service:
     build: ./src/backend_service
     image: procezeus/backend_service
+    restart: always
     depends_on:
       - postgresql_db
       - nlp_service
@@ -25,6 +24,7 @@ services:
       - procezeus_net
   web_client:
     build: ./src/web_client
+    restart: always
     image: procezeus/web_client
     depends_on:
       - backend_service
@@ -32,6 +32,7 @@ services:
       - procezeus_net
   postgresql_db:
     image: postgres
+    restart: always
     volumes:
       - procezeus_db:/var/lib/postgresql/data
     networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,17 +6,20 @@ services:
       - 3001:3001
     volumes:
       - ./src/ml_service:/usr/src/app
+    command: gunicorn -w 3 --log-level DEBUG --reload -b 0.0.0.0:3001 app:app
   nlp_service:
     ports:
       - 3002:3002
     volumes:
       - ./src/nlp_service:/usr/src/app
       - /usr/src/app/data
+    command: gunicorn -w 3 --log-level DEBUG --reload -b 0.0.0.0:3002 app:app
   backend_service:
     ports:
       - 3003:3003
     volumes:
       - ./src/backend_service:/usr/src/app
+    command: gunicorn -w 3 --log-level DEBUG --reload -b 0.0.0.0:3003 app:app
   web_client:
     command: npm start
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,8 +19,6 @@ services:
       - ./src/backend_service:/usr/src/app
   web_client:
     command: npm start
-    depends_on:
-      - backend_service
     ports:
       - 3039:3039
     volumes:

--- a/src/backend_service/Dockerfile
+++ b/src/backend_service/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 ENV FLASK_APP=app.py
 EXPOSE 3003
-CMD [ "gunicorn", "-w 3", "--reload", "-b 0.0.0.0:3003", "app:app" ]
+CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3003", "app:app" ]

--- a/src/ml_service/Dockerfile
+++ b/src/ml_service/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 ENV FLASK_APP=app.py
 EXPOSE 3001
-CMD [ "gunicorn", "-w 3", "--reload", "-b 0.0.0.0:3001", "app:app" ]
+CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3001", "app:app" ]

--- a/src/nlp_service/Dockerfile
+++ b/src/nlp_service/Dockerfile
@@ -11,4 +11,4 @@ COPY . .
 RUN python init.py
 ENV FLASK_APP=app.py
 EXPOSE 3002
-CMD [ "gunicorn", "-w 3", "--reload", "-b 0.0.0.0:3002", "app:app" ]
+CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3002", "app:app" ]


### PR DESCRIPTION
[#15]

- [x] Adds service dependencies to base docker configuration in order  to prevent failure when spinning up services.
- [x] Sets log level in gunicorn to DEBUG to show Flask debug messages

This prevents failures on `./cjl up` where the backend_service loads and attempts to connect before the database service has spun up.

