### PR TITLE
[#15] Allows Docker containers to write to host directories

### DIFF
--- a/cjl
+++ b/cjl
@@ -28,6 +28,8 @@ if [ -z "$COMPOSE_FILE" ]; then
 fi
 
 # Passes script arguments to docker-compose
+sudo find ./src -type d -exec chmod 777 {} \;
+sudo find ./src -type f -exec chmod 666 {} \;
 COMPOSE="docker-compose -f docker-compose.base.yml -f docker-compose.$COMPOSE_FILE.yml $@"
 bash -c "$COMPOSE"
 

--- a/cjl
+++ b/cjl
@@ -28,8 +28,6 @@ if [ -z "$COMPOSE_FILE" ]; then
 fi
 
 # Passes script arguments to docker-compose
-sudo find ./src -type d -exec chmod 777 {} \;
-sudo find ./src -type f -exec chmod 666 {} \;
 COMPOSE="docker-compose -f docker-compose.base.yml -f docker-compose.$COMPOSE_FILE.yml $@"
 bash -c "$COMPOSE"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,18 +4,28 @@ services:
   ml_service:
     ports:
       - 3001:3001
+    volumes:
+      - ./src/ml_service:/usr/src/app
   nlp_service:
     ports:
       - 3002:3002
+    volumes:
+      - ./src/nlp_service:/usr/src/app
+      - /usr/src/app/data
   backend_service:
     ports:
       - 3003:3003
+    volumes:
+      - ./src/backend_service:/usr/src/app
   web_client:
     command: npm start
     depends_on:
       - backend_service
     ports:
       - 3039:3039
+    volumes:
+      - ./src/web_client:/usr/src/app
+      - /usr/src/app/node_modules
   postgresql_db:
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET


### PR DESCRIPTION
[#15]

- [x] Reintroduce shared volumes between Docker container and host
- [x] Allows Docker containers to write to host directories

During development, the containers are reading from and writing to the host's file system. 

The implication of reading from the host filesystem is that fancy development features like auto-watching files and hot module reloading now works from within the Docker container.

The implication of writing to the host filesystem is that the Docker container is now able to write data files or generate dependencies that are currently required for running the `web_client` and `nlp_service` services.