### PR TITLE
[#15] Adds autopep8 dependency to requirements_test.txt for all python-based services

### DIFF
--- a/src/backend_service/requirements_test.txt
+++ b/src/backend_service/requirements_test.txt
@@ -4,4 +4,4 @@
 
 pytest
 pytest-cov
-flake8
+autopep8

--- a/src/ml_service/requirements_test.txt
+++ b/src/ml_service/requirements_test.txt
@@ -4,4 +4,4 @@
 
 pytest
 pytest-cov
-flake8
+autopep8

--- a/src/nlp_service/requirements_test.txt
+++ b/src/nlp_service/requirements_test.txt
@@ -4,5 +4,5 @@
 
 pytest
 pytest-cov
-flake8
+autopep8
 


### PR DESCRIPTION
[#15]

- [x] Adds autopep8 dependency to requirements_test.txt for all python-based services

Related PR: #89 