### PR TITLE
[#5] get legal documents endpoint

### DIFF
--- a/src/backend_service/README.md
+++ b/src/backend_service/README.md
@@ -265,3 +265,18 @@ Downloads a file uploaded as part of a conversation
 **Code** : `400 Bad Request`
 
 **Code** : `404 Not Found`
+
+---
+
+# Get Latest Legal Documents
+
+Obtains information and contents of the latest legal documents
+
+**URL** : `/legal`
+
+**Method** : `GET`
+
+## Success Response
+
+**Code** : `200 OK`
+

--- a/src/backend_service/app.py
+++ b/src/backend_service/app.py
@@ -14,7 +14,7 @@ ma = Marshmallow(app)
 # Cors Setup
 CORS(app)
 
-from controllers import conversationController
+from controllers import conversationController, legalController
 
 
 @app.route("/new", methods=['POST'])
@@ -58,3 +58,8 @@ def get_files(conversation_id=None, file_id=None):
         return conversationController.get_file(conversation_id, file_id)
     else:
         abort(make_response(jsonify(message="Invalid request"), 400))
+
+
+@app.route("/legal", methods=['GET'])
+def get_legal_documents():
+    return legalController.get_legal_documents()

--- a/src/backend_service/controllers/legalController.py
+++ b/src/backend_service/controllers/legalController.py
@@ -5,6 +5,7 @@ import os
 import re
 import json
 
+
 def get_legal_documents():
     filepaths = glob(os.getcwd() + '/legal/*.json')
     filenames = [filepath.split('/').pop() for filepath in filepaths]

--- a/src/backend_service/controllers/legalController.py
+++ b/src/backend_service/controllers/legalController.py
@@ -1,15 +1,9 @@
 import flask
-from flask import jsonify, abort, make_response
+from flask import jsonify
 from glob import glob
 import os
 import re
 import json
-
-from models.models import *
-from services import nlpService, fileService
-from services.factService import FactService
-from services.staticStrings import *
-
 
 def get_legal_documents():
     filepaths = glob(os.getcwd() + '/legal/*.json')

--- a/src/backend_service/controllers/legalController.py
+++ b/src/backend_service/controllers/legalController.py
@@ -1,0 +1,39 @@
+import flask
+from flask import jsonify, abort, make_response
+from glob import glob
+import os
+import re
+import json
+
+from models.models import *
+from services import nlpService, fileService
+from services.factService import FactService
+from services.staticStrings import *
+
+
+def get_legal_documents():
+    filepaths = glob(os.getcwd() + '/legal/*.json')
+    filenames = [filepath.split('/').pop() for filepath in filepaths]
+
+    # Find all document types and their highest version numbers
+    highest_document_version = {}
+    for filename in filenames:
+        match = re.search('(.+)-v(\d+)\.json', filename)
+        if match:
+            document_type = match.group(1)
+            version_number = int(match.group(2))
+            if document_type in highest_document_version:
+                if version_number > highest_document_version[document_type]:
+                    highest_document_version[document_type] = version_number
+            else:
+                highest_document_version[document_type] = version_number
+
+    # Read documents as JSON for highest versions
+    document_list = []
+    for document, version in highest_document_version.items():
+        document_path = os.getcwd() + '/legal/{}-v{}.json'.format(document, version)
+        with open(document_path, 'r') as f:
+            document_dict = json.load(f)
+        document_list.append(document_dict)
+
+    return jsonify(document_list)

--- a/src/backend_service/legal/eula-v1.json
+++ b/src/backend_service/legal/eula-v1.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "type": "End User License Agreement",
+  "abbreviation": "EULA",
+  "time_created": "2017-10-26T20:52:41-04:00",
+  "html": "<strong>This</strong><p>is</p><hr/> test document until <ol><li>actual</li></ol> legal doc is <ul><li>drafted</li></ul>."
+}


### PR DESCRIPTION
[#5]

- [x] Creates the `GET /legal` endpoint to return information and contents of the latest legal documents

This is accomplished by keeping structured JSON documents in the `legal` directory with the appropriate filename and version.
