### PR TITLE
[#66] Always read DB password from environment variable, for both backend and DB services

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,6 +7,8 @@ services:
     command: bash -c 'pytest && if ! [ -z "$$(autopep8 -dr .)" ]; then autopep8 -dr .; exit 1; fi;'
   backend_service:
     command: bash -c 'pytest && if ! [ -z "$$(autopep8 -dr .)" ]; then autopep8 -dr .; exit 1; fi;'
+    environment:
+      POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   web_client:
     command: bash -c "npm run test && npm run lint"
   postgresql_db:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,8 @@ services:
     volumes:
       - ./src/backend_service:/usr/src/app
     command: gunicorn -w 3 --log-level DEBUG --reload -b 0.0.0.0:3003 app:app
+    environment:
+      POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   web_client:
     command: npm start
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,10 +10,12 @@ services:
   backend_service:
     ports:
       - 3003:3003
+    environment:
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
   web_client:
     command: npm start
     ports:
       - 3039:3039
   postgresql_db:
     environment:
-      - POSTGRES_PASSWORD
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,8 @@ services:
     command: npm start
     ports:
       - 3039:3039
+    environment:
+      NODE_ENV: production
   postgresql_db:
     environment:
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD

--- a/src/backend_service/Dockerfile
+++ b/src/backend_service/Dockerfile
@@ -9,5 +9,6 @@ RUN pip install --no-cache-dir -r requirements_test.txt
 COPY . .
 
 ENV FLASK_APP=app.py
+ENV POSTGRES_PASS
 EXPOSE 3003
 CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3003", "app:app" ]

--- a/src/backend_service/Dockerfile
+++ b/src/backend_service/Dockerfile
@@ -9,6 +9,5 @@ RUN pip install --no-cache-dir -r requirements_test.txt
 COPY . .
 
 ENV FLASK_APP=app.py
-ENV POSTGRES_PASS
 EXPOSE 3003
 CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3003", "app:app" ]

--- a/src/backend_service/app.py
+++ b/src/backend_service/app.py
@@ -3,12 +3,12 @@ from flask_cors import CORS
 from flask_marshmallow import Marshmallow
 
 import database
+import os
 
 app = Flask(__name__)
 
 # DB Setup
-# db = database.connect(app, 'postgres', 'postgres', 'postgres', host="localhost")
-db = database.connect(app, 'postgres', 'DEV_PASS_NOT_SECRET', 'postgres')
+db = database.connect(app, 'postgres', os.environ['POSTGRES_PASSWORD'], 'postgres')
 ma = Marshmallow(app)
 
 # Cors Setup

--- a/src/web_client/config/prod.env.js
+++ b/src/web_client/config/prod.env.js
@@ -1,4 +1,4 @@
 module.exports = {
   NODE_ENV: '"production"',
-  API_URL: '"https://capstone.cyberjustice.ca/"'
+  API_URL: '"https://capstone.cyberjustice.ca:3003/"'
 }


### PR DESCRIPTION
[#66]

- [x] Sets default passwords for the database as environment variables for the dev and CI docker-compose environments
- [x] Sets prod docker-compose environment to read environment variable from the host
- [x] Uses the production node.js configuration for web client in production environment