### PR TITLE
[#112] Changes person type resolution flow

### DIFF
--- a/src/backend_service/README.md
+++ b/src/backend_service/README.md
@@ -40,6 +40,10 @@ Provide the user's name and person type.
 }
 ```
 
+## Error Response
+
+**Code** : `400 Bad Request` - *Invalid person_type provided*
+
 ---
 
 # Send a message
@@ -281,3 +285,45 @@ Obtains information and contents of the latest legal documents
 
 **Code** : `200 OK`
 
+**Content examples**
+
+```json
+[
+    {
+        "abbreviation": "EULA",
+        "html": {
+            "content": [
+                {
+                    "subtitle": "TL;DR",
+                    "summary": "no purse as fully me or point. Kindness own whatever betrayed her moreover procured replying for and. Proposal indulged no do do sociable he throwing settling. Covered ten nor comfort offices carried. Age she way earnestly the fulfilled extremely.",
+                    "text": "Prevailed sincerity behaviour to so do principle mr. As departure at no propriety zealously my. On dear rent if girl view. First on smart there he sense. Earnestly enjoyment her you resources. Brother chamber ten old against. Mr be cottage so related minuter is. Delicate say and blessing ladyship exertion few margaret. Delight herself welcome against smiling its for. Suspected discovery by he affection household of principle perfectly he.",
+                    "title": "DESCRIPTION OF SERVICE"
+                },
+                {
+                    "subtitle": "TL;DR",
+                    "summary": "Scarcely on striking packages by so property in delicate. Up or well must less rent read walk so be. Easy sold at do hour sing spot. Any meant has cease too the decay. Since party burst am it match. By or blushes between besides offices noisier as.",
+                    "text": "It prepare is ye nothing blushes up brought. Or as gravity pasture limited evening on. Wicket around beauty say she. Frankness resembled say not new smallness you discovery. Noisier ferrars yet shyness weather ten colonel. Too him himself engaged husband pursuit musical. Man age but him determine consisted therefore. Dinner to beyond regret wished an branch he. Remain bed but expect suffer little repair.",
+                    "title": "ACCEPTANCE OF TERMS"
+                },
+                {
+                    "subtitle": "TL;DR",
+                    "summary": "Luckily friends do ashamed to do suppose. Tried meant mr smile so. Exquisite behaviour as to middleton perfectly.",
+                    "text": "He my polite be object oh change. Consider no mr am overcame yourself throwing sociable children. Hastily her totally conduct may. My solid by stuff first smile fanny. Humoured how advanced mrs elegance sir who. Home sons when them dine do want to. Estimating themselves unsatiable imprudence an he at an. Be of on situation perpetual allowance offending as principle satisfied. Improved carriage securing are desirous too.",
+                    "title": "MODIFICATION OF TERMS"
+                },
+                {
+                    "subtitle": "TL;DR",
+                    "summary": "Improved own provided blessing may peculiar domestic. Sight house has sex never. No visited raising gravity outward subject my cottage mr be. Hold do at tore in park feet near my case.",
+                    "text": "Extremely we promotion remainder eagerness enjoyment an. Ham her demands removal brought minuter raising invited gay. Contented consisted continual curiosity contained get sex. Forth child dried in in aware do. You had met they song how feel lain evil near. Small she avoid six yet table china. And bed make say been then dine mrs. To household rapturous fulfilled attempted on so. ",
+                    "title": "REGISTRATION"
+                }
+            ],
+            "header": "End User License Agreement",
+            "subheader": "Savings her pleased are several started females met. Short her not among being any. Thing of judge fruit charm views do. Miles mr an forty along as he. She education get middleton day agreement performed preserved unwilling. Do however as pleased offence outward beloved by present. By outward neither he so covered amiable greater. Juvenile proposal betrayed he an informed weddings followed. Precaution day see imprudence sympathize principles. At full leaf give quit to in they up."
+        },
+        "time_created": "2017-10-26T20:52:41-04:00",
+        "type": "End User License Agreement",
+        "version": 1
+    }
+]
+```

--- a/src/backend_service/README.md
+++ b/src/backend_service/README.md
@@ -20,11 +20,12 @@ Initializes a new conversation
 
 **Data constraints**
 
-Provide the user's name
+Provide the user's name and person type.
 
 ```json
 {
-    "name": "[unicode 40 chars max]"
+    "name": "[unicode 40 chars max]",
+    "person_type": "(TENANT|LANDLORD)"
 }
 ```
 ## Success Response
@@ -70,7 +71,7 @@ Simple response containing a message.
 ```json
 {
     "conversation_id": 1,
-    "message": "Hello Tim Timmens, are you a landlord or a tenant?"
+    "message": "Hello Tim Timmens, what kind of problem are you having?"
 }
 ```
 
@@ -82,7 +83,7 @@ Response containing a request for a file.
     "file_request": {
         "document_type": "LEASE"
     },
-    "message": "So Tim Timmens, I see you're a tenant. What issue can I help you with today?"
+    "message": "Could you please upload your lease if you have it, Tim Timmens?"
 }
 ```
 

--- a/src/backend_service/app.py
+++ b/src/backend_service/app.py
@@ -20,7 +20,7 @@ from controllers import conversationController, legalController
 @app.route("/new", methods=['POST'])
 def init_conversation():
     init_request = request.get_json()
-    return conversationController.init_conversation(init_request['name'])
+    return conversationController.init_conversation(init_request['name'], init_request['person_type'])
 
 
 @app.route("/conversation", methods=['POST'])

--- a/src/backend_service/controllers/conversationController.py
+++ b/src/backend_service/controllers/conversationController.py
@@ -18,8 +18,11 @@ def get_conversation(conversation_id):
     return ConversationSchema().jsonify(conversation)
 
 
-def init_conversation(name):
-    conversation = Conversation(name=name)
+def init_conversation(name, person_type):
+    if person_type.upper() not in PersonType.__members__:
+        return abort(make_response(jsonify(message="Invalid person type provided"), 400))
+
+    conversation = Conversation(name=name, person_type=PersonType[person_type.upper()])
 
     # Persist new conversation to DB
     db.session.add(conversation)

--- a/src/backend_service/controllers/conversationController.py
+++ b/src/backend_service/controllers/conversationController.py
@@ -169,10 +169,7 @@ def __get_conversation(conversation_id):
 
 def __generate_response(conversation, message):
     if __has_just_accepted_disclaimer(conversation):
-        response_text = StaticStrings.chooseFrom(StaticStrings.welcome).format(name=conversation.name)
-        return {'response_text': response_text}
-    if conversation.person_type is None:
-        return __determine_person_type(conversation, message)
+        return __ask_initial_question(conversation)
     elif conversation.claim_category is None:
         return __determine_claim_category(conversation, message)
     elif conversation.current_fact is not None:
@@ -190,35 +187,23 @@ def __generate_response(conversation, message):
         return {'response_text': question}
 
 
-def __determine_person_type(conversation, message):
-    person_type = None
-    nlp_request = nlpService.fact_extract(['tenant_landlord'], message)
+def __ask_initial_question(conversation):
+    person_type = conversation.person_type
 
-    for fact in nlp_request['facts']:
-        person_type = fact['tenant_landlord']
+    file_request = None
+    if person_type is PersonType.TENANT:
+        file_request = FileRequest(document_type=DocumentType.LEASE)
 
-    if person_type is not None:
-        conversation.person_type = {
-            'tenant': PersonType.TENANT,
-            'landlord': PersonType.LANDLORD
-        }[person_type]
+    db.session.commit()
 
-        file_request = None
-        if person_type == 'tenant':
-            file_request = FileRequest(document_type=DocumentType.LEASE)
+    # Generate response based on person type
+    response = None
+    if person_type is PersonType.TENANT:
+        response = StaticStrings.chooseFrom(StaticStrings.problem_inquiry_tenant).format(name=conversation.name)
+    elif person_type is PersonType.LANDLORD:
+        response = StaticStrings.chooseFrom(StaticStrings.problem_inquiry_landlord).format(name=conversation.name)
 
-        db.session.commit()
-
-        # Generate response based on person type
-        response = None
-        if person_type == 'tenant':
-            response = StaticStrings.chooseFrom(StaticStrings.problem_inquiry_tenant).format(name=conversation.name)
-        elif person_type == 'landlord':
-            response = StaticStrings.chooseFrom(StaticStrings.problem_inquiry_landlord).format(name=conversation.name)
-
-        return {'response_text': response, 'file_request': file_request}
-    else:
-        return {'response_text': StaticStrings.chooseFrom(StaticStrings.clarify)}
+    return {'response_text': response, 'file_request': file_request}
 
 
 def __determine_claim_category(conversation, message):

--- a/src/backend_service/services/staticStrings.py
+++ b/src/backend_service/services/staticStrings.py
@@ -7,14 +7,6 @@ class StaticStrings:
         "Hello {name}! Before we start, I want to make it clear that I am not a replacement for a lawyer and any information I provide you with is not meant to be construed as legal advice. Always check in with your legal professional. You can read more about our terms of use <a href='/legal' target='_blank'>here</a>. Do you accept these conditions?"
     ]
 
-    # Asking for person type
-    welcome = [
-        "Hello {name}! To start off, are you a landlord or a tenant?",
-        "Hey {name}, I'm here to help you with your rental disputes! Are you a landlord or a tenant?",
-        "Nice to meet you {name}, are you a landlord or a tenant?",
-        "You've got questions, I've got answers! Are you a landlord or a tenant, {name}?"
-    ]
-
     # Asking for initial problem description
     problem_inquiry_landlord = [
         "So {name}, I see you're a landlord. What issue can I help you with today?",


### PR DESCRIPTION
[#112]
- [x] Changes conversation creation endpoint to require both 'name' and 'person_type' attributes
- [x] Asking whether user is tenant/landlord no longer part of conversation. Accepting EULA will lead immediately to problem inquiry.