### PR TITLE
[#75] HOTFIX: Fixes app module import in backend service.

### DIFF
--- a/src/backend_service/app.py
+++ b/src/backend_service/app.py
@@ -2,8 +2,6 @@ import os
 
 from flask import Flask, request, abort, make_response, jsonify
 from flask_cors import CORS
-
-from controllers import conversationController, legalController
 from postgresql_db import database
 
 # Flask Setup
@@ -15,6 +13,7 @@ db = database.connect(app, 'postgres', os.environ['POSTGRES_PASSWORD'], 'postgre
 # Cors Setup
 CORS(app)
 
+from controllers import conversationController, legalController
 
 @app.route("/new", methods=['POST'])
 def init_conversation():


### PR DESCRIPTION
[#75]

- [x] HOTFIX: Fixes app module import in backend service.

This runtime error was able to make it's way through our unti tests, and was later caught through manual testing. This may have been inadvertently introduced while introducing the PYTHONPATH environment variable to all services (#174) or when removing functions previously used to modify the system path (#179).