### PR TITLE
[#156] Optimizes existing Docker builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+comment:
+  behavior: default
+  layout: header, diff
+  require_changes: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment:
-  behavior: default
-  layout: header, diff
-  require_changes: false

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@
 course-admin/
 images/
 meta-documents/
-.git/
 **/.gitignore
 **/.dockerignore
 **/*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Generated files
+**/node_modules
+**/.cache
+**/__pycache__
+**/.idea
+**/npm-debug.log
+**/DS_Store
+
+# Files that should not be sent to Docker daemon
+course-admin/
+images/
+meta-documents/
+.git/
+**/.gitignore
+**/.dockerignore
+**/*.md
+**/Dockerfile
+cjl
+
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,33 +4,23 @@ services:
   ml_service:
     ports:
       - 3001:3001
-    volumes:
-      - ./src/ml_service:/usr/src/app/src/ml_service
-    command: gunicorn -w 3 --log-level DEBUG --reload -b 0.0.0.0:3001 app:app
+    command: gunicorn -w 3 --log-level DEBUG -b 0.0.0.0:3001 app:app
   nlp_service:
     ports:
       - 3002:3002
-    volumes:
-      - ./src/nlp_service:/usr/src/app/src/nlp_service
-      - /usr/src/app/src/nlp_service/data
     command: python -m flask run --host 0.0.0.0 -p 3002
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   backend_service:
     ports:
       - 3003:3003
-    volumes:
-      - ./src/backend_service:/usr/src/app/src/backend_service
-    command: gunicorn -w 3 --log-level DEBUG --reload -b 0.0.0.0:3003 app:app
+    command: gunicorn -w 3 --log-level DEBUG -b 0.0.0.0:3003 app:app
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   web_client:
     command: npm start
     ports:
       - 3039:3039
-    volumes:
-      - ./src/web_client:/usr/src/app/src/web_client
-      - /usr/src/app/src/web_client/node_modules
   postgresql_db:
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET

--- a/src/backend_service/Dockerfile
+++ b/src/backend_service/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3
 
+EXPOSE 3003
 ENV PYTHONPATH /usr/src/app/src:/usr/src/app/src/backend_service
+ENV FLASK_APP=app.py
 
 WORKDIR /usr/src/app
 
@@ -10,10 +12,9 @@ COPY ./src/backend_service/requirements.txt ./src/backend_service/
 COPY ./src/backend_service/requirements_test.txt ./src/backend_service/
 RUN pip install http://initd.org/psycopg/upload/psycopg2-2.7.3.1.dev0/psycopg2-2.7.3.1.dev0-cp36-cp36m-manylinux1_x86_64.whl && \
     pip install -r ./src/backend_service/requirements_test.txt
+
 COPY . .
 
 WORKDIR /usr/src/app/src/backend_service
 
-ENV FLASK_APP=app.py
-EXPOSE 3003
 CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3003", "app:app" ]

--- a/src/ml_service/Dockerfile
+++ b/src/ml_service/Dockerfile
@@ -1,14 +1,16 @@
 FROM python:3
+
+EXPOSE 3001
 ARG CJL_USER
 ARG CJL_PASS
 ENV CJL_USER ${CJL_USER}
 ENV CJL_PASS ${CJL_PASS}
 ENV PYTHONPATH /usr/src/app/src:/usr/src/app/src/ml_service
-
+ENV FLASK_APP=app.py
 
 WORKDIR /usr/src/app
 
-RUN mkdir -p /usr/src/app/src/ml_service
+RUN mkdir -p /usr/src/app/src/ml_service/word_vectors/
 
 COPY ./src/ml_service/requirements.txt ./src/ml_service/
 COPY ./src/ml_service/requirements_test.txt ./src/ml_service/
@@ -16,12 +18,12 @@ RUN pip install -r ./src/ml_service/requirements_test.txt
 
 RUN pip install hdbscan
 
+COPY ./src/ml_service/init.py ./src/ml_service/
+RUN cd src/ml_service && python init.py
+
 COPY . .
 
-RUN cd src/ml_service && python init.py
 
 WORKDIR /usr/src/app/src/ml_service
 
-ENV FLASK_APP=app.py
-EXPOSE 3001
 CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3001", "app:app" ]

--- a/src/nlp_service/Dockerfile
+++ b/src/nlp_service/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3
 
+EXPOSE 3002
+ENV FLASK_APP=app.py
 ENV PYTHONPATH /usr/src/app/src:/usr/src/app/src/nlp_service
+
 WORKDIR /usr/src/app
 
 RUN mkdir -p /usr/src/app/src/nlp_service
@@ -10,16 +13,17 @@ COPY ./src/nlp_service/requirements_test.txt ./src/nlp_service/
 RUN pip install http://initd.org/psycopg/upload/psycopg2-2.7.3.1.dev0/psycopg2-2.7.3.1.dev0-cp36-cp36m-manylinux1_x86_64.whl && \
     pip install -r ./src/nlp_service/requirements_test.txt
 
-COPY . .
-
 # Initialize spacy
 RUN python -m spacy download en
+
+COPY ./src/nlp_service/init_rasa.py ./src/nlp_service
+COPY ./src/nlp_service/rasa ./src/nlp_service/rasa
 
 # Train RASA classifier
 RUN cd src/nlp_service && python init_rasa.py
 
+COPY . .
+
 WORKDIR /usr/src/app/src/nlp_service
 
-ENV FLASK_APP=app.py
-EXPOSE 3002
 CMD [ "python", "-m", "flask", "run", "--host", "0.0.0.0", "-p", "3002" ]

--- a/src/nlp_service/requirements.txt
+++ b/src/nlp_service/requirements.txt
@@ -1,4 +1,3 @@
-gunicorn==19.7.1
 click==6.7
 Flask==0.12.2
 itsdangerous==0.24

--- a/src/web_client/.dockerignore
+++ b/src/web_client/.dockerignore
@@ -1,2 +1,0 @@
-node_modules/
-npm-debug.log

--- a/src/web_client/Dockerfile
+++ b/src/web_client/Dockerfile
@@ -1,18 +1,20 @@
 FROM node:8.9.0
 
+EXPOSE 3039
+ENV PORT=3039
+
+RUN apt-get install git -y
+
 WORKDIR /usr/src/app
 
 RUN mkdir -p /usr/src/app/src/web_client
 
-RUN apt-get install git -y
+COPY ./src/web_client/package.json ./src/web_client/
+
+RUN cd ./src/web_client && npm install
 
 COPY . .
 
 WORKDIR /usr/src/app/src/web_client
 
-RUN npm install
-
-
-EXPOSE 3039
-ENV PORT=3039
 CMD [ "npm", "start"]


### PR DESCRIPTION
[#156]

- [x] Removes all volumes in development. This was proving to be troublesome because it would write new files to the host filesystem on every `./cjl build`, which means that nothing ever got cached.
- [x] Creates a global `.dockerignore` file to reduce number of files sent to the Docker daemon as part of the build context.
- [x] Performs heavier caching and layering for `./cjl build` for every service

Previous builds on the local machine would take approximately 5 or 10 minutes. Here are some very unofficial benchmarks that these changes bring in specific instances:

- If no files were changed since your last build: `4.722s`
- If you changed a "trivial" source file (almost everything except `requirements.txt`/`package.json` and `init.py`): `38.093s`
