### PR TITLE
[#210] Bot will specify when a claim category is unimplemented

### DIFF
--- a/src/nlp_service/controllers/nlpController.py
+++ b/src/nlp_service/controllers/nlpController.py
@@ -63,20 +63,25 @@ def classify_claim_category(conversation_id, message):
         first_fact = factService.submit_claim_category(conversation.claim_category)
         first_fact_id = first_fact['fact_id']
 
-        # Retrieve the Fact from DB
-        first_fact = db.session.query(Fact).get(first_fact_id)
+        if first_fact_id:
+            # Retrieve the Fact from DB
+            first_fact = db.session.query(Fact).get(first_fact_id)
 
-        # Save first fact as current fact
-        conversation.current_fact = first_fact
+            # Save first fact as current fact
+            conversation.current_fact = first_fact
 
-        # Commit
-        db.session.commit()
+            # Commit
+            db.session.commit()
 
-        # Generate next message
-        first_fact_question = Responses.fact_question(first_fact.name)
-        response = Responses.chooseFrom(Responses.category_acknowledge).format(
-            claim_category=conversation.claim_category.value.lower().replace("_", " "),
-            first_question=first_fact_question)
+            # Generate next message
+            first_fact_question = Responses.fact_question(first_fact.name)
+            response = Responses.chooseFrom(Responses.category_acknowledge).format(
+                claim_category=conversation.claim_category.value.lower().replace("_", " "),
+                first_question=first_fact_question)
+        else:
+            response = Responses.chooseFrom(Responses.category_acknowledge).format(
+                claim_category=conversation.claim_category.value.lower().replace("_", " "),
+                first_question=Responses.chooseFrom(Responses.unimplemented_category_error))
     else:
         response = Responses.chooseFrom(Responses.clarify).format(previous_question="")
 

--- a/src/nlp_service/services/responseStrings.py
+++ b/src/nlp_service/services/responseStrings.py
@@ -2,11 +2,17 @@ import random
 
 
 class Responses:
+
+    # Respond that a particular claim category is not implemented yet
+    unimplemented_category_error = [
+        "Unfortunately, I cannot help with these types of issues right now."
+    ]
+
     # Acknowledge claim category resolution
     category_acknowledge = [
         "I see, you're having issues with {claim_category}. {first_question}",
         "As I understand it, your problems have to do with {claim_category}. {first_question}",
-        "Oh yes, I know all about problems with {claim_category}. {first_question}"
+        "Oh yes, I see you're having problems with {claim_category}. {first_question}"
     ]
 
     # Asking for clarification


### PR DESCRIPTION
[#210]

Quick fix for error @choitwao discovered wherein first_fact_id in nlpController was being returned as None and crashing the application when an unimplemented claim category was determined.

If the claim category has no implementation (ie: no facts), and the user's input determines they need help with that issue, the bot will respond that it cannot help right now. 