### PR TITLE
[#315] Enabled comments in custom json scripts

### DIFF
--- a/src/nlp_service/util/parse_dataset.py
+++ b/src/nlp_service/util/parse_dataset.py
@@ -22,6 +22,7 @@ class CreateJson:
     ENTITY_SYNONYM_HEADER = re.compile('\[entity_synonyms\]')
     TEXT_HEADER = re.compile('\[common_examples:.*\]')
     EMPTY_LINE = re.compile('\s*')
+    COMMENTED_LINE = re.compile('#')
 
     nlu_dict = {"rasa_nlu_data":
                 {
@@ -133,6 +134,9 @@ class CreateJson:
                 self.state = StateEnum.TEXT
 
             elif len(line) < 5:
+                pass
+
+            elif self.COMMENTED_LINE.search(line):
                 pass
 
             elif self.state == StateEnum.META:

--- a/src/nlp_service/util/parse_dataset.py
+++ b/src/nlp_service/util/parse_dataset.py
@@ -22,7 +22,7 @@ class CreateJson:
     ENTITY_SYNONYM_HEADER = re.compile('\[entity_synonyms\]')
     TEXT_HEADER = re.compile('\[common_examples:.*\]')
     EMPTY_LINE = re.compile('\s*')
-    COMMENTED_LINE = re.compile('#')
+    COMMENTED_LINE = re.compile('^#')
 
     nlu_dict = {"rasa_nlu_data":
                 {

--- a/src/nlp_service/util/parse_dataset_test.py
+++ b/src/nlp_service/util/parse_dataset_test.py
@@ -14,6 +14,7 @@ money: $\d(.)?+|\d(.)?+$
 entity: synonym1, synonym2
 
 [common_examples: true]
+# comment
 my landlord increased my rent by ($500)
 i owe my landlord (40 dollars)
 


### PR DESCRIPTION
Any line starting with '#' will be commented

example: #comment
example: # comment
example: \s\s\s\s\s\s\s # \s\s\s\\s\s\s\s\s\       comment