### PR TITLE
[#261] Integrates precedent similarity into prediction statement

### DIFF
--- a/src/ml_service/README.md
+++ b/src/ml_service/README.md
@@ -138,15 +138,22 @@ Provide facts_vector and demands_vector, with key values for each fact/demand.
 ```json
 {
     "outcomes_vector": {
-      "lease_resiliation" : 1,
+      "orders_resiliation" : 1,
       ...
     },
     "similar_precedents" : [
-        ["AZ-1111111", 1.23123],
-        ["AZ-2222222", 1.23123],
-        ["AZ-3333333", 1.23123],
-        ["AZ-4444444", 1.23123],
-        ["AZ-5555555", 1.23123]
+    	{
+    		"precedent": "AZ-1111111",
+    		"distance": 1.23123
+    	},
+    	{
+    		"precedent": "AZ-2222222",
+    		"distance": 1.23123
+    	},
+    	{
+    		"precedent": "AZ-3333333",
+    		"distance": 1.23123
+    	}
     ]
 }
 ```

--- a/src/ml_service/web/ml_controller.py
+++ b/src/ml_service/web/ml_controller.py
@@ -12,7 +12,6 @@ class MlController:
     regression_model = MultiOutputRegression()
     similar_finder = SimilarFinder()
 
-
     @staticmethod
     def predict_outcome(input_json):
         """
@@ -41,9 +40,9 @@ class MlController:
         outcome_vector = MlController.regression_model.predict(facts_vector, outcome_vector)
         response = MlController.vector_to_dict(outcome_vector)
         similar_dict = {'facts_vector': facts_vector, 'outcomes_vector': outcome_vector}
-        response['similar_precedents'] = MlController.similar_finder.get_most_similar(similar_dict)
+        response['similar_precedents'] = MlController.format_similar_precedents(
+            MlController.similar_finder.get_most_similar(similar_dict))
         return response
-
 
     @staticmethod
     def dict_to_vector(input_dict):
@@ -72,3 +71,18 @@ class MlController:
             label = MlController.classifier_labels[outcome_index][0]
             return_dict[label] = str(outcome_vector[outcome_index])
         return {'outcomes_vector': return_dict}
+
+    @staticmethod
+    def format_similar_precedents(similarity_list):
+        """
+        Formats a list such as ["AZ-111111", 1.5] into a list of dicts of the form
+        [{"precedent": "AZ-111111","distance": 1.5}]
+        :param similarity_list: List of lists of the form ["PRECEDENT_NAME"(string), DISTANCE(number)]
+        :return: A formatted list of precedents
+        """
+        formatted_precedents = []
+
+        for precedent_array in similarity_list:
+            formatted_precedents.append({"precedent": precedent_array[0], "distance": precedent_array[1]})
+
+        return formatted_precedents

--- a/src/ml_service/web/ml_controller.py
+++ b/src/ml_service/web/ml_controller.py
@@ -83,6 +83,6 @@ class MlController:
         formatted_precedents = []
 
         for precedent_array in similarity_list:
-            formatted_precedents.append({"precedent": precedent_array[0], "distance": precedent_array[1]})
+            formatted_precedents.append({"precedent": precedent_array[0].split(".")[0], "distance": precedent_array[1]})
 
         return formatted_precedents

--- a/src/ml_service/web/ml_controller_test.py
+++ b/src/ml_service/web/ml_controller_test.py
@@ -152,3 +152,22 @@ class TestMlController(unittest.TestCase):
             }
         }
         self.assertEqual(expected_dict, result)
+
+    def test_format_similar_precedents(self):
+        similarity_list = [
+            ["AZ-11111.txt", 1.5],
+            ["AZ-22222", 1.0]
+        ]
+        expected_list = [
+            {
+                "precedent": "AZ-11111",
+                "distance": 1.5
+            },
+            {
+                "precedent": "AZ-22222",
+                "distance": 1.0
+            }
+        ]
+
+        formatted_list = MlController.format_similar_precedents(similarity_list)
+        self.assertDictEqual(formatted_list, expected_list)

--- a/src/ml_service/web/ml_controller_test.py
+++ b/src/ml_service/web/ml_controller_test.py
@@ -170,4 +170,4 @@ class TestMlController(unittest.TestCase):
         ]
 
         formatted_list = MlController.format_similar_precedents(similarity_list)
-        self.assertDictEqual(formatted_list, expected_list)
+        self.assertListEqual(formatted_list, expected_list)

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -131,11 +131,15 @@ def classify_fact_value(conversation_id, message):
             # All facts have been resolved, submit request to ML service for prediction
             ml_prediction = ml_service.submit_resolved_fact_list(conversation)
 
-            prediction_dict = ml_service.extract_prediction(claim_category=conversation.claim_category.value,
-                                                            ml_response=ml_prediction)
+            prediction_dict, similar_precedent_list = ml_service.extract_prediction(
+                claim_category=conversation.claim_category.value,
+                ml_response=ml_prediction)
 
             # Generate statement for prediction
-            question = Responses.prediction_statement(conversation.claim_category.value, prediction_dict)
+            question = Responses.prediction_statement(
+                claim_category_value=conversation.claim_category.value,
+                prediction_dict=prediction_dict,
+                similar_precedent_list=similar_precedent_list)
     else:
         question = Responses.chooseFrom(Responses.clarify).format(
             previous_question=Responses.fact_question(current_fact.name))
@@ -159,7 +163,7 @@ def __classify_claim_category(message, person_type):
     classify_dict = rasaClassifier.classify_problem_category(message, person_type)
     log.debug(
         "\nClassify Claim Category\n\tPerson Type: {}\n\tMessage: {}\n\tOutput: {}".format(person_type, message,
-                                                                                        classify_dict))
+                                                                                           classify_dict))
 
     # Return the claim category, or None if the answer was insufficient in determining one
     if intentThreshold.is_sufficient(classify_dict):

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -131,9 +131,11 @@ def classify_fact_value(conversation_id, message):
             # All facts have been resolved, submit request to ML service for prediction
             ml_prediction = ml_service.submit_resolved_fact_list(conversation)
 
-            prediction_dict, similar_precedent_list = ml_service.extract_prediction(
+            prediction_dict = ml_service.extract_prediction(
                 claim_category=conversation.claim_category.value,
                 ml_response=ml_prediction)
+
+            similar_precedent_list = ml_prediction['similar_precedents']
 
             # Generate statement for prediction
             question = Responses.prediction_statement(

--- a/src/nlp_service/services/ml_service.py
+++ b/src/nlp_service/services/ml_service.py
@@ -26,7 +26,7 @@ def extract_prediction(claim_category, ml_response):
     Given a claim category and the ml service response, will extract the prediction performing any necessary mappings.
     :param claim_category: The current conversation's claim category as a string
     :param ml_response: The response dict received from ml service
-    :return: Tuple containing dict of relevant outcomes for the claim category and the list of similar precedents returned my ML service
+    :return: Dict of relevant outcomes for the claim category returned by ML service
     """
 
     relevant_outcomes = {
@@ -47,7 +47,7 @@ def extract_prediction(claim_category, ml_response):
         for outcome in outcome_list:
             resolved_outcomes[outcome] = ml_response['outcomes_vector'][outcome]
 
-    return resolved_outcomes, ml_response['similar_precedents']
+    return resolved_outcomes
 
 
 def generate_demand_dict():

--- a/src/nlp_service/services/ml_service.py
+++ b/src/nlp_service/services/ml_service.py
@@ -26,7 +26,7 @@ def extract_prediction(claim_category, ml_response):
     Given a claim category and the ml service response, will extract the prediction performing any necessary mappings.
     :param claim_category: The current conversation's claim category as a string
     :param ml_response: The response dict received from ml service
-    :return: Dict of relevant outcomes for the claim category returned my ML service
+    :return: Tuple containing dict of relevant outcomes for the claim category and the list of similar precedents returned my ML service
     """
 
     relevant_outcomes = {
@@ -47,7 +47,7 @@ def extract_prediction(claim_category, ml_response):
         for outcome in outcome_list:
             resolved_outcomes[outcome] = ml_response['outcomes_vector'][outcome]
 
-    return resolved_outcomes
+    return resolved_outcomes, ml_response['similar_precedents']
 
 
 def generate_demand_dict():

--- a/src/nlp_service/services/response_strings_test.py
+++ b/src/nlp_service/services/response_strings_test.py
@@ -31,16 +31,25 @@ class TestResponse(unittest.TestCase):
         self.assertTrue(statement_landlord in Responses.static_claim_responses["missing_response"])
 
     def test_responses_prediction(self):
-        question = Responses.prediction_statement("LEASE_TERMINATION", {"orders_resiliation": 1})
+        question = Responses.prediction_statement("LEASE_TERMINATION", {"orders_resiliation": 1}, [])
         self.assertTrue(question in self.responseInstance.prediction["LEASE_TERMINATION"]["orders_resiliation"][True])
 
     def test_responses_prediction_false(self):
-        question = Responses.prediction_statement("LEASE_TERMINATION", {"orders_resiliation": 0})
+        question = Responses.prediction_statement("LEASE_TERMINATION", {"orders_resiliation": 0}, [])
         self.assertTrue(question in self.responseInstance.prediction["LEASE_TERMINATION"]["orders_resiliation"][False])
 
     def test_responses_prediction_empty(self):
-        question_bad_category = Responses.prediction_statement("does_not_exist", {})
-        question_empty_predictions = Responses.prediction_statement("LEASE_TERMINATION", {})
+        question_bad_category = Responses.prediction_statement("does_not_exist", {}, [])
+        question_empty_predictions = Responses.prediction_statement("LEASE_TERMINATION", {}, [])
 
         self.assertTrue(question_bad_category in self.responseInstance.prediction["missing_category"])
         self.assertTrue(question_empty_predictions in self.responseInstance.prediction["missing_category"])
+
+    def test_responses_prediction_precedent(self):
+        question = Responses.prediction_statement("LEASE_TERMINATION", {"orders_resiliation": 1}, [
+            {
+                "precedent": "AZ-11111",
+                "distance": 1.5
+            }
+        ])
+        self.assertIn("AZ-11111", question)


### PR DESCRIPTION
[#261] 

- [X] When a prediction is made and similar precedents are returned by the ml service, they will be displayed to the user.
- [X] Similar precedents are displayed in ascending distance order.
- [X] Changes the format in which similar precedents are returned by ml service to make them more readable.

![similar_precedents](https://user-images.githubusercontent.com/1418403/35889377-4f9bae30-0b69-11e8-84d4-b57ca31a9b6c.PNG)

 