### PR TITLE
[#315] Fixes true, false misclassifications for several facts

### DIFF
--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -192,7 +192,8 @@ def __extract_entity(current_fact_name, current_fact_type, message):
             return None
 
     classify_dict = rasaClassifier.classify_fact(current_fact_name, message)
-    log.debug("\nClassify Fact\n\tMessage: {}\n\tOutput: {}".format(message, classify_dict))
+    log.debug("\nClassify Fact\n\tMessage: {}\n\tFact Name: {}\n\tOutput: {}".format(message, current_fact_name,
+                                                                                     classify_dict))
 
     # Return the fact value, or None if the answer was insufficient in determining one
     if intentThreshold.is_sufficient(classify_dict):

--- a/src/nlp_service/rasa/text/fact/base/yes_no.txt
+++ b/src/nlp_service/rasa/text/fact/base/yes_no.txt
@@ -8,11 +8,14 @@ true: (yes)|(true)|(correct)|(yeah)|(yea)|(yup(pers)?)|(right)|(surely)|(exactly
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
 yea
+yep
 aye aye
 roger
 10-4
@@ -32,6 +35,7 @@ undoubtedly
 mhmm
 
 [common_examples: false]
+negative
 that is incorrect
 false
 absolutely not
@@ -44,7 +48,7 @@ niet
 nay
 nah
 no absolutely not
-no way Jose
+no way jose
 out of the question
 no siree
 no sir

--- a/src/nlp_service/rasa/text/fact/individual/landlord_serious_prejudice.txt
+++ b/src/nlp_service/rasa/text/fact/individual/landlord_serious_prejudice.txt
@@ -1,60 +1,107 @@
 [meta]
 
 [regex_features]
+gender: (him|he|her|she|they)((')?s)?
 
 [entity_synonyms]
 
 [common_examples: true]
-the tenant’s payment habits has cause me prejudice.
-the tenant’s payment habits has caused me trouble.
-i was counting on their payments for my projects.
-i needed the tenant’s money.
-the tenant didn’t pay and it is troublesome for me.
-the tenant didn’t pay and it is troublesome.
-it is hard for me to sustain myself because of his late payments.
-it is hard for me to sustain myself because of his habits.
-their negligence is causing me problems.
-his negligence is causing me problems.
-the tenant’s is unbearable.
-it is hard to bear the consequences caused by my tenant.
-the consequences are grave.
-i bear many consequences from his negligence.
-the times have been hard because of their habits.
-i just manage to get through considering their habits.
-yes it has and it isn’t easy for me.
-absolutely.
-yes and i think it is a lack of respect towards me.
-it is hard for me to reach ends meet.
-i cannot manage to reach ends meet because of the tenant.
-i experience many problems due to these circumstances.
-their non payment is an absolute abomination towards my life.
-the tenant’s prejudice has brought a great deal of calamity into my life.
-my life is now filled with void and sorrow.
-yes, my life now feels like a rollercoaster of pain.
-it is hard to cope with.
-madness has consumed my way of living.
+absolutely
+affirmative
+totally
+true
+that's correct
+yeah
+yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
+the tenant’s payment habits has cause me prejudice
+the tenant’s payment habits has caused me trouble
+i was counting on their payments for my projects
+i needed the tenant’s money
+the tenant didn’t pay and it is troublesome for me
+the tenant didn’t pay and it is troublesome
+it is hard for me to sustain myself because of his late payments
+it is hard for me to sustain myself because of his habits
+their negligence is causing me problems
+his negligence is causing me problems
+the tenant’s is unbearable
+it is hard to bear the consequences caused by my tenant
+the consequences are grave
+i bear many consequences from his negligence
+the times have been hard because of their habits
+i just manage to get through considering their habits
+yes it has and it isn’t easy for me
+yes and i think it is a lack of respect towards me
+it is hard for me to reach ends meet
+i cannot manage to reach ends meet because of the tenant
+i experience many problems due to these circumstances
+their non payment is an absolute abomination towards my life
+the tenant’s prejudice has brought a great deal of calamity into my life
+my life is now filled with void and sorrow
+yes, my life now feels like a rollercoaster of pain
+it is hard to cope with
+madness has consumed my way of living
 
 [common_examples: false]
-the tenant’s payment habits has not caused me any prejudice.
-the tenant’s payment habits has not caused me trouble.
-i was not counting on their payments for my projects.
-i did not need the tenant’s money.
-the tenant didn’t pay but it was not troublesome for me.
+negative
+that is incorrect
+false
+absolutely not
+nope
+no way
+no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
+the tenant’s payment habits has not caused me any prejudice
+the tenant’s payment habits has not caused me trouble
+i was not counting on their payments for my projects
+i did not need the tenant’s money
+the tenant didn’t pay but it was not troublesome for me
 the tenant didn’t pay but it was fine
-it is not hard for me to sustain myself because of his late payments.
-it is not hard for me to sustain myself because of his habits.
-their negligence is not causing me problems.
-his negligence is not causing me problems.
-the tenant’s habits are bearable.
-it is not hard to bear the consequences caused by my tenant.
-the consequences are not so bad.
-i bear little consequences from his negligence.
+it is not hard for me to sustain myself because of his late payments
+it is not hard for me to sustain myself because of his habits
+their negligence is not causing me problems
+his negligence is not causing me problems
+the tenant’s habits are bearable
+it is not hard to bear the consequences caused by my tenant
+the consequences are not so bad
+i bear little consequences from his negligence
 i live just fine
 yes it has but it is fine
-absolutely not.
-it is not hard for me to reach ends meet.
-i can still manage to reach ends meet because of the tenant.
-i do not experience many problems due to these circumstances.
+it is not hard for me to reach ends meet
+i can still manage to reach ends meet because of the tenant
+i do not experience many problems due to these circumstances
 their habits has not caused me too much harm
 i do not feel any prejudice
 there is no prejudice

--- a/src/nlp_service/rasa/text/fact/individual/tenant_continuous_late_payment.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_continuous_late_payment.txt
@@ -1,10 +1,37 @@
 [meta]
 
 [regex_features]
+gender: (him|he|her|she|they)((')?s)?
 
 [entity_synonyms]
 
 [common_examples: true]
+absolutely
+affirmative
+totally
+true
+that's correct
+yeah
+yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 the tenant has been continuously late on payments
 the tenant has not paid in a long time
 the tenant last paid a long time ago
@@ -17,13 +44,31 @@ the tenant refuses to pay on time
 he pays but it is always late
 i have never received a payment on time.
 their payments are often late
-yes
-affirmative
-roger
 he always pays in an untimely manner.
 
 [common_examples: false]
 negative
+that is incorrect
+false
+absolutely not
+nope
+no way
+no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 their payment habits are good
 he always pays on time
 it is rare that he pays late

--- a/src/nlp_service/rasa/text/fact/individual/tenant_financial_problem.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_financial_problem.txt
@@ -1,8 +1,7 @@
 [meta]
 
 [regex_features]
-false: (no)|(No)|(NO)
-true: (yes)|(YES)|(Yes)
+gender: (him|he|her|she|they)((')?s)?
 that's: that is|that's
 conditionpoor: (suffer)|(lost)|(debt)|(die(d)?)|(death)|(depression)|(injur(ed|y)?)|
 conditiongood: (lazy)|(not true)|(fine)|(able)
@@ -11,10 +10,31 @@ conditiongood: (lazy)|(not true)|(fine)|(able)
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 yes the tenant suffered a job injury
 yes the tenant is suffering from depression
 this is correct the tenant had a death in the family
@@ -28,12 +48,28 @@ I heard but i don’t give a shit
 
 
 [common_examples: false]
+negative
 that is incorrect
 false
 absolutely not
 nope
 no way
 no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 no he is perfectly able
 no he is just lazy
 untrue he just smokes pot all day

--- a/src/nlp_service/rasa/text/fact/individual/tenant_left_without_paying.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_left_without_paying.txt
@@ -11,10 +11,31 @@ notabandon: (still (t)?here)|(not gone)|(in (his|the) apartment)|(present)|(arou
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 i haven’t been able to contact the tenant
 i haven’t seen the tenant in weeks
 the guy disappeared completely

--- a/src/nlp_service/rasa/text/fact/individual/tenant_owes_rent.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_owes_rent.txt
@@ -34,12 +34,28 @@ i’m waiting for him to give me my (twenty dollar bill)
 yeah i’m still waiting for my (8523.24$)
 
 [common_examples: false]
+negative
 that is incorrect
-no
 false
 absolutely not
 nope
 no way
+no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 no he always pays on time
 they pay on time
 i’m not owed any rent

--- a/src/nlp_service/rasa/text/fact/individual/tenant_rent_not_paid_less_3_weeks.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_rent_not_paid_less_3_weeks.txt
@@ -1,18 +1,38 @@
 [meta]
 
 [regex_features]
-false: (no)|(No)|(NO)
-true: (yes)|(YES)|(Yes)
-that's: that is|that's 
+gender: (him|he|her|she|they)((')?s)?
+that's: that is|that's
 
 [entity_synonyms]
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 yes it has been less than 3 weeks
 it has been 2 weeks
 the tenant paid rent this week
@@ -22,12 +42,28 @@ they paid me this week
 they only paid me a few days late
 
 [common_examples: false]
+negative
 that is incorrect
 false
 absolutely not
 nope
 no way
 no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 it has been longer than 3 weeks since they paid me
 they paid me more than a month ago
 they are at least 3 weeks behind on rent

--- a/src/nlp_service/rasa/text/fact/individual/tenant_rent_not_paid_more_3_weeks.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_rent_not_paid_more_3_weeks.txt
@@ -1,18 +1,38 @@
 [meta]
 
 [regex_features]
-false: (no)|(No)|(NO)
-true: (yes)|(YES)|(Yes)
+gender: (him|he|her|she|they)((')?s)?
 that's: that is|that's 
 
 [entity_synonyms]
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 it has been longer than 3 weeks since they paid me
 they paid me more than a month ago
 they are at least 3 weeks behind on rent
@@ -24,12 +44,28 @@ yes they still haven’t paid me
 
 
 [common_examples: false]
+negative
 that is incorrect
 false
 absolutely not
 nope
 no way
 no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 no it has been less than 3 weeks
 it has been 2 weeks
 the tenant paid rent this week
@@ -37,4 +73,3 @@ they paid me this week
 the tenant has recently paid me
 they paid me this week
 they only paid me a few days late
-

--- a/src/nlp_service/rasa/text/fact/individual/tenant_rent_paid_before_hearing.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_rent_paid_before_hearing.txt
@@ -1,18 +1,38 @@
 [meta]
 
 [regex_features]
-false: (no)|(No)|(NO)
-true: (yes)|(YES)|(Yes)
+gender: (him|he|her|she|they)((')?s)?
 that's: that is|that's 
 
 [entity_synonyms]
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 yes, they recently paid me
 yes they have paid the balance
 they paid the remaining balance before the hearing
@@ -21,12 +41,28 @@ the tenants paid all the rent before the hearing
 the tenants successfully paid off the balance
 
 [common_examples: false]
+negative
 that is incorrect
 false
 absolutely not
 nope
 no way
 no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 the hearing past and they still haven’t paid me money
 no I haven’t seen my rent money yet
 the tenants refuse to pay

--- a/src/nlp_service/rasa/text/fact/individual/tenant_withold_rent_without_permission.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_withold_rent_without_permission.txt
@@ -1,27 +1,63 @@
 [meta]
 
 [regex_features]
-false: (no)|(No)|(NO)
-true: (yes)|(YES)|(Yes)
+gender: (him|he|her|she|they)((')?s)?
 that's: that is|that's 
 
 [entity_synonyms]
 
 [common_examples: true]
 absolutely
+affirmative
+totally
 true
 that's correct
 yeah
 yes
+yea
+yep
+aye aye
+roger
+10-4
+uh-huh
+righto
+right
+yup
+yuppers
+right on
+ja
+surely
+exactly
+yessir
+yes sir
+alright
+undoubtedly
+mhmm
 yes the tenant refused to pay me for random reasons
 yes the tenant hasn’t paid for a while
 
 [common_examples: false]
+negative
 that is incorrect
 false
 absolutely not
 nope
 no way
 no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
 no the tenant paid the rent
 no the tenant always pay on time


### PR DESCRIPTION
[#315]

- [X] Fixes data sets of facts not generated from the base yes-no training data which would sometimes miss-classify yes no answers
- [X] Adds gender regex to some of the training data

In a future iteration, this should be addressed by adding an import feature to the json creator tool.