### PR TITLE
[#44] Adds conversation progress to messaging endpoint

### DIFF
--- a/src/backend_service/README.md
+++ b/src/backend_service/README.md
@@ -109,14 +109,17 @@ Provide the conversation_id and a message. Message should be empty string for fi
 
 **Content examples**
 
-Simple response containing a message. Messages may contain pipe characters (|) which indicate that a sentence should be split into separate conversation windows. Note that the first message will not contain a pipe character. Each subsequent sentence will begin with a pipe character if it is meant to be split.
+Simple response containing a message and conversation progress. Messages may contain pipe characters (|) which indicate that a sentence should be split into separate conversation windows. Note that the first message will not contain a pipe character. Each subsequent sentence will begin with a pipe character if it is meant to be split.
+
+Converation progress will be null at the beginning of the conversation, and if the user ends up asking a FAQ question (which have no progress). However, if the user asks a question that requires the bot to resolve facts, progress will indicate a percentage of how far along the conversation is to getting a prediction.
 
 ### Example 1:
 
 ```json
 {
     "conversation_id": 1,
-    "message": "Hello Tim Timmens!|What kind of problem are you having?"
+    "message": "Hello Tim Timmens!|What kind of problem are you having?",
+    "progress": null
 }
 ```
 
@@ -131,7 +134,8 @@ Message 2: What kind of problem are you having?
 ```json
 {
     "conversation_id": 5,
-    "message": "Oh I see you're having problems with lease termination!|I have a few questions for you.|Do you have a lease?"
+    "message": "Oh I see you're having problems with lease termination!|I have a few questions for you.|Do you have a lease?",
+    "progress": 0
 }
 ```
 
@@ -396,7 +400,7 @@ Removes a resolved fact from the conversation
 
 ---
 
-# Upload a file 
+# Upload a file
 
 Upload a file that serves as evidence for a particular conversation.
 
@@ -461,7 +465,7 @@ Gets a list of file metadata for a conversation
 			"type": "application/pdf",
 			"timestamp": "2017-10-24T00:01:30.000000+00:00"
 		}
-	]	
+	]
 }
 ```
 

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -103,6 +103,7 @@ def receive_message(conversation_id, message):
     enforce_possible_answer = False
 
     user_message = None
+    conversation_progress = 0
 
     # First message in the conversation
     if len(conversation.messages) == 0:
@@ -120,6 +121,7 @@ def receive_message(conversation_id, message):
         # Generate response text & optional parameters
         response = __generate_response(conversation, user_message.text)
         response_text = response.get('response_text')
+        conversation_progress = response.get('conversation_progress', default=0)
         file_request = response.get('file_request')
         possible_answers = response.get('possible_answers')
 
@@ -145,7 +147,10 @@ def receive_message(conversation_id, message):
     db.session.commit()
 
     # Build response dict
-    response_dict = {'conversation_id': conversation.id}
+    response_dict = {
+        'conversation_id': conversation.id,
+        'progress': conversation_progress
+    }
 
     if response_text is not None:
         response_dict['message'] = response_text
@@ -281,7 +286,7 @@ def __generate_response(conversation, message):
         # Refresh the session, since nlp_service may have modified conversation
         db.session.refresh(conversation)
 
-        return {'response_text': nlp_request['message']}
+        return {'response_text': nlp_request['message'], 'conversation_progress': nlp_request['conversation_progress']}
 
 
 def __ask_initial_question(conversation):

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -11,6 +11,12 @@ from app import db
 ########################
 # Conversation Handling
 ########################
+# Logging
+import logging
+import sys
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 def get_conversation(conversation_id):
@@ -121,7 +127,8 @@ def receive_message(conversation_id, message):
         # Generate response text & optional parameters
         response = __generate_response(conversation, user_message.text)
         response_text = response.get('response_text')
-        conversation_progress = response.get('conversation_progress', default=0)
+        conversation_progress = response.get('conversation_progress')
+        log.debug("Progress: {}".format(conversation_progress))
         file_request = response.get('file_request')
         possible_answers = response.get('possible_answers')
 
@@ -279,7 +286,7 @@ def __generate_response(conversation, message):
         # Refresh the session, since nlp_service may have modified conversation
         db.session.refresh(conversation)
 
-        return {'response_text': nlp_request['message']}
+        return {'response_text': nlp_request['message'], 'conversation_progress': nlp_request['conversation_progress']}
     else:
         nlp_request = nlp_service.submit_message(conversation.id, message)
 

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -11,13 +11,6 @@ from app import db
 ########################
 # Conversation Handling
 ########################
-# Logging
-import logging
-import sys
-
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-log = logging.getLogger(__name__)
-
 
 def get_conversation(conversation_id):
     """
@@ -128,7 +121,6 @@ def receive_message(conversation_id, message):
         response = __generate_response(conversation, user_message.text)
         response_text = response.get('response_text')
         conversation_progress = response.get('conversation_progress')
-        log.debug("Progress: {}".format(conversation_progress))
         file_request = response.get('file_request')
         possible_answers = response.get('possible_answers')
 

--- a/src/nlp_service/README.md
+++ b/src/nlp_service/README.md
@@ -36,7 +36,8 @@ Provide the conversation id and the message.
 
 ```json
 {
-    "message": "I see you're having problems with lease termination. Have you kept up with your rent payments?"
+    "message": "I see you're having problems with lease termination. Have you kept up with your rent payments?",
+    "progress": 0
 }
 ```
 
@@ -73,7 +74,8 @@ Provide the conversation id and the message.
 
 ```json
 {
-    "message": "Have you kept up with your rent payments?"
+    "message": "Have you kept up with your rent payments?",
+    "progress": 10
 }
 ```
 
@@ -91,8 +93,8 @@ The **util.parse_dataset.py** module and the associated **CreateJson** class can
 #### Format
 ```
 [meta]
-() = entity_name1,entity_extractor(optional)
-{} = entity_name2,entity_extractor(optional)
+() = entity_name1, entity_extractor(optional)
+{} = entity_name2, entity_extractor(optional)
 
 [regex_features]
 name:regex
@@ -100,13 +102,14 @@ name:regex
 [entity_synonyms]
 entity:synonym1, synonym2
 
-[common_examples:intent_name1]
+[common_examples: intent_name1]
 sentence1
 sentence2
 
-[common_examples:intent_name2]
+[common_examples: intent_name2]
 sentence1
 sentence2
+
 ```
 
 - **[]** are reserved characters used to identify sections
@@ -119,19 +122,20 @@ sentence2
 #### Example
 ```
 [meta]
-() = money,ner_duckling
+() = money, ner_duckling
 
 [regex_features]
 money:$\d(.)?+|\d(.)?+$
 
-[common_examples:true]
+[common_examples: true]
 my landlord increased my rent by ($500)
 i owe my landlord (40 dollars)
 
-[common_examples:false]
+[common_examples: false]
 i don't owe my landlord any money
 i dont have any debts
 no
+
 ```
 
 ### Command Line Use

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -45,8 +45,6 @@ def classify_claim_category(conversation_id, message):
     if conversation_id is None or message is None:
         abort(make_response(jsonify(message="Must provide conversation_id and message"), 400))
 
-    conversation_progress = None
-
     # Retrieve conversation
     conversation = db.session.query(Conversation).get(conversation_id)
 
@@ -82,9 +80,6 @@ def classify_claim_category(conversation_id, message):
             # Commit
             db.session.commit()
 
-            # Set the conversation progress
-            conversation_progress = __calculate_conversation_progress(conversation)
-
             # Generate next message
             first_fact_question = Responses.fact_question(first_fact.name)
             response = Responses.chooseFrom(Responses.category_acknowledge).format(
@@ -99,7 +94,7 @@ def classify_claim_category(conversation_id, message):
 
     return jsonify({
         "message": response,
-        "conversation_progress": conversation_progress
+        "conversation_progress": __calculate_conversation_progress(conversation)
     })
 
 

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -326,7 +326,7 @@ def __calculate_conversation_progress(conversation):
         conversation_progress = (resolved_important_fact_count + resolved_additional_fact_count) / \
                                 (important_fact_count + additional_facts)
 
-    return conversation_progress * 100
+    return int(conversation_progress * 100)
 
 
 def __classify_acknowledgement(message):

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -136,7 +136,6 @@ def classify_fact_value(conversation_id, message):
     # Commit
     db.session.commit()
 
-    log.debug("Progress: {}".format(__calculate_conversation_progress(conversation)))
     return jsonify({
         "message": question,
         "conversation_progress": __calculate_conversation_progress(conversation)

--- a/src/nlp_service/services/fact_service.py
+++ b/src/nlp_service/services/fact_service.py
@@ -177,6 +177,18 @@ def has_additional_facts(conversation):
     return True
 
 
+def count_important_facts_resolved(conversation):
+    """
+    :param conversation: The current conversation
+    :return: Returns the count of how many additional facts have been resolved
+    """
+
+    all_category_facts = get_category_fact_list(conversation.claim_category.value)
+    facts_resolved = get_resolved_fact_keys(conversation)
+    important_facts_resolved = [fact for fact in all_category_facts["facts"] if fact in facts_resolved]
+    return len(important_facts_resolved)
+
+
 def count_additional_facts_resolved(conversation):
     """
     :param conversation: The current conversation

--- a/src/nlp_service/services/fact_service_test.py
+++ b/src/nlp_service/services/fact_service_test.py
@@ -153,6 +153,15 @@ class FactServiceTest(unittest.TestCase):
 
         self.assertFalse(fact_service.has_additional_facts(conversation))
 
+    def test_count_important_facts_resolved(self):
+        conversation = Conversation(name="Bob", person_type=PersonType.TENANT,
+                                    claim_category=ClaimCategory.LEASE_TERMINATION)
+        db.session.add(conversation)
+        db.session.commit()
+
+        important_fact_count = fact_service.count_important_facts_resolved(conversation)
+        self.assertTrue(important_fact_count == 0)
+
     def test_count_additional_facts_resolved(self):
         conversation = Conversation(name="Bob", person_type=PersonType.TENANT,
                                     claim_category=ClaimCategory.LEASE_TERMINATION)


### PR DESCRIPTION
[#44]

- [X] Adds progress percentage to backend POST /conversation endpoint

Documented in backend_service README.md. Here is a short summary:
1. Progress is only returned when chatting. It is not an attribute of the conversation. Thus will not be present when fetching the conversation directly by id.
2. The progress is null if there is no fact resolution required. Therefore when a claim category is being determined or when the user has asked a FAQ question, progress will be null. This can be used to determine whether or not to show a progress bar.
3. Progress will be a whole number (%), with 100% triggering a new prediction. 
4. If additional facts are asked, the % is reduced, and a new prediction will be given when it reaches 100%.