### PR TITLE
[#345] Fix continuous delivery (CD) build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_script: echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 script:
   - "COMPOSE_FILE=ci ./cjl run --no-deps -d postgresql_db && ./cjl build $SERVICE && COMPOSE_FILE=ci ./cjl run --no-deps $CI_ENV $SERVICE"
 after_success:
-  - if [ $TRAVIS_BRANCH == "master" ]; then sudo apt-get update -y && sudo apt-get install software-properties-common -y && sudo apt-get install sshpass ansible -y && sudo bash -c "echo \"capstone.cyberjustice.ca ansible_user=$CAPSTONE_SSH_USER ansible_ssh_pass=$CAPSTONE_SSH_PASS\" >> /etc/ansible/hosts" && ansible all -m shell -a "cd /home/$CAPSTONE_SSH_USER/JusticeAI && git pull && ./cjl down && ./cjl build --no-cache && ./cjl up -d"; fi;
+  - if [ $TRAVIS_BRANCH == "master" ]; then sudo apt-get update -y && sudo apt-get install software-properties-common -y && sudo apt-get install sshpass ansible -y && sudo bash -c "echo \"capstone.cyberjustice.ca ansible_host=capstone.cyberjustice.ca ansible_user=$CAPSTONE_SSH_USER ansible_ssh_user=$CAPSTONE_SSH_USER ansible_pass=$CAPSTONE_SSH_PASS ansible_ssh_pass=$CAPSTONE_SSH_PASS\" >> /etc/ansible/hosts"ansible all -u "$CAPSTONE_SSH_USER" -m shell -a "cd /home/$CAPSTONE_SSH_USER/JusticeAI && git pull && ./cjl down && ./cjl build --no-cache && ./cjl up -d"; fi;
+
 
 
 notifications:

--- a/src/nlp_service/requirements.txt
+++ b/src/nlp_service/requirements.txt
@@ -26,12 +26,12 @@ jsonschema==2.6.0
 matplotlib==2.1.0
 requests==2.18.4
 tqdm==4.19.5
-numpy==1.14.0
+numpy==1.14.1
 simplejson==3.13.2
 cloudpickle==0.5.2
 
 # Rasa Sklearn Dependencies
-spacy==2.0.5
+spacy==2.0.8
 scikit-learn==0.19.1
 scipy==1.0.0
 sklearn-crfsuite==0.3.6

--- a/src/nlp_service/requirements.txt
+++ b/src/nlp_service/requirements.txt
@@ -26,12 +26,13 @@ jsonschema==2.6.0
 matplotlib==2.1.0
 requests==2.18.4
 tqdm==4.19.5
-numpy==1.14.1
+numpy==1.14.0
 simplejson==3.13.2
 cloudpickle==0.5.2
+msgpack-python==0.5.4
 
 # Rasa Sklearn Dependencies
-spacy==2.0.8
+spacy==2.0.5
 scikit-learn==0.19.1
 scipy==1.0.0
 sklearn-crfsuite==0.3.6


### PR DESCRIPTION
[#345]
- [x] Fix continuous delivery (CD) build failures by specifying additional Ansible SSH configuration
- [x] Fix nlp_service build failures by pinning a specific dependency version