### PR TITLE
[#345] Ensures all Python-based services uniformly use Flask as opposed to Gunicorn

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
   ml_service:
     ports:
       - 3001:3001
-    command: gunicorn -w 3 --log-level DEBUG -b 0.0.0.0:3001 app:app
+    command: python -m flask run --host 0.0.0.0 -p 3001
   nlp_service:
     ports:
       - 3002:3002
@@ -14,7 +14,7 @@ services:
   backend_service:
     ports:
       - 3003:3003
-    command: gunicorn -w 3 --log-level DEBUG -b 0.0.0.0:3003 app:app
+    command: python -m flask run --host 0.0.0.0 -p 3003
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   task_service:

--- a/src/backend_service/Dockerfile
+++ b/src/backend_service/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 WORKDIR /usr/src/app/src/backend_service
 
-CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3003", "app:app" ]
+CMD [ "python", "-m", "flask", "run", "--host", "0.0.0.0", "-p", "3003" ]

--- a/src/backend_service/requirements.txt
+++ b/src/backend_service/requirements.txt
@@ -1,4 +1,3 @@
-gunicorn==19.7.1
 click==6.7
 Flask==0.12.2
 itsdangerous==0.24

--- a/src/ml_service/Dockerfile
+++ b/src/ml_service/Dockerfile
@@ -27,4 +27,4 @@ COPY . .
 
 WORKDIR /usr/src/app/src/ml_service
 
-CMD [ "gunicorn", "-w 3", "-b 0.0.0.0:3001", "app:app" ]
+CMD [ "python", "-m", "flask", "run", "--host", "0.0.0.0", "-p", "3001" ]

--- a/src/ml_service/requirements.txt
+++ b/src/ml_service/requirements.txt
@@ -3,7 +3,6 @@ click==6.7
 Cython==0.27.2
 Flask==0.12.2
 gensim==3.0.1
-gunicorn==19.7.1
 h5py==2.7.1
 itsdangerous==0.24
 Jinja2==2.9.6


### PR DESCRIPTION
[#345]

- [x] Ensures all Python-based services uniformly use Flask as opposed to Gunicorn

Reasons for this change:
- @Vynny previously had issues with Gunicorn's multiple workers.
- Logging output did not behave as expected.
- Minimize differences in Dockerfiles for Python-based services
- Speed is not a concern at this stage, so offers no benefit 
- One less dependency to download at build time