### PR TITLE
[#236] Removes task_service from build until it is needed again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   matrix:
     - SERVICE=ml_service
     - SERVICE=nlp_service
-    - SERVICE=task_service
     - SERVICE=web_client
     - SERVICE=backend_service
 

--- a/cjl
+++ b/cjl
@@ -64,8 +64,6 @@ if [ "$1" == "test" ]; then
     docker-compose -f docker-compose.base.yml -f docker-compose.test.yml run ml_service
   elif [ "$2" == "nlp_service" ]; then
     docker-compose -f docker-compose.base.yml -f docker-compose.test.yml run nlp_service
-  elif [ "$2" == "task_service" ]; then
-    docker-compose -f docker-compose.base.yml -f docker-compose.test.yml run task_service
   elif [ "$2" == "web_client" ]; then
     docker-compose -f docker-compose.base.yml -f docker-compose.test.yml run web_client
   else

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -4,7 +4,7 @@ services:
   ml_service:
     build:
       context: .
-      dockerfile: ./src/ml_service/Dockerfile
+      dockerfile: src/ml_service/Dockerfile
       args:
       - CJL_USER
       - CJL_PASS
@@ -15,7 +15,7 @@ services:
   nlp_service:
     build:
       context: .
-      dockerfile: ./src/nlp_service/Dockerfile
+      dockerfile: src/nlp_service/Dockerfile
       args:
       - CJL_USER
       - CJL_PASS
@@ -26,7 +26,7 @@ services:
   backend_service:
     build:
       context: .
-      dockerfile: ./src/backend_service/Dockerfile
+      dockerfile: src/backend_service/Dockerfile
     image: procezeus/backend_service
     restart: always
     depends_on:
@@ -37,7 +37,7 @@ services:
   web_client:
     build:
       context: .
-      dockerfile: ./src/web_client/Dockerfile
+      dockerfile: src/web_client/Dockerfile
     restart: always
     image: procezeus/web_client
     depends_on:

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -23,17 +23,6 @@ services:
     restart: always
     networks:
       - procezeus_net
-  task_service:
-    build:
-      context: .
-      dockerfile: ./src/task_service/Dockerfile
-      args:
-      - CJL_USER
-      - CJL_PASS
-    image: procezeus/task_service
-    restart: always
-    networks:
-      - procezeus_net
   backend_service:
     build:
       context: .

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -11,11 +11,6 @@ services:
     environment:
       CI: "true"
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
-  task_service:
-    command: bash -c 'pytest &&  autopep8 -dr . && bash <(curl -s https://codecov.io/bash)'
-    environment:
-      CI: "true"
-      POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   backend_service:
     command: bash -c 'pytest && autopep8 -dr . && bash <(curl -s https://codecov.io/bash)'
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,12 +17,6 @@ services:
     command: python -m flask run --host 0.0.0.0 -p 3003
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
-  task_service:
-    ports:
-      - 3004:3004
-    command: python -m flask run --host 0.0.0.0 -p 3004
-    environment:
-      POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   web_client:
     command: npm start
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,11 +14,6 @@ services:
       - 3003:3003
     environment:
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
-  task_service:
-    ports:
-      - 3004:3004
-    environment:
-      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
   web_client:
     command: npm start
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,10 +9,6 @@ services:
     command: bash -c 'pytest -l --tb=long --timeout=200 &&  autopep8 -dr .'
     environment:
       POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
-  task_service:
-    command: bash -c 'pytest && autopep8 -dr .'
-    environment:
-      POSTGRES_PASSWORD: DEV_PASS_NOT_SECRET
   backend_service:
     command: bash -c 'pytest && autopep8 -dr .'
     environment:


### PR DESCRIPTION
[#236]

- [x] Removes task_service from build until it is used at which point it can be reintroduced
- [x] Removes './' in docker-compose configuration for specifying the path of a Dockerfile