### PR TITLE
[#43] Report Generation and Endpoint

### DIFF
--- a/src/backend_service/README.md
+++ b/src/backend_service/README.md
@@ -327,6 +327,161 @@ Gets the message history for a conversation
 **Code** : `404 Not Found`
 
 ---
+
+# Get a report for a conversation
+
+Retrieves a report for a conversation once at least one prediction has been returned. Will return 404 if a report has not been generated yet.
+
+**URL** : `/conversation/:conversation_id/report`
+
+**Method** : `GET`
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content examples**
+
+```json
+{
+	"report": {
+		"accuracy": 0.8114285714285714,
+		"curves": {
+			"additional_indemnity_money": {
+				"mean": 1477.7728467101024,
+				"outcome_value": 6038,
+				"std": 1927.8147997893939,
+				"variance": 3716469.9022870203
+			}
+		},
+		"data_set": 8,
+		"outcomes": {
+			"additional_indemnity_money": 6038,
+			"landlord_prejudice_justified": true,
+			"orders_expulsion": true,
+			"orders_immediate_execution": true,
+			"orders_resiliation": true,
+			"tenant_ordered_to_pay_landlord": 3092,
+			"tenant_ordered_to_pay_landlord_legal_fees": 80
+		},
+		"similar_case": 5,
+		"similar_precedents": [
+			{
+				"distance": 2.6080129205467784,
+				"facts": {
+					"landlord_relocation_indemnity_fees": 0,
+					"tenant_dead": false,
+					"tenant_is_bothered": false,
+					"tenant_left_without_paying": false,
+					"tenant_owes_rent": 0,
+					"tenant_rent_not_paid_more_3_weeks": true
+				},
+				"outcomes": {
+					"additional_indemnity_money": 5850,
+					"landlord_prejudice_justified": true,
+					"orders_expulsion": true,
+					"orders_immediate_execution": true,
+					"orders_resiliation": true,
+					"tenant_ordered_to_pay_landlord": 7150,
+					"tenant_ordered_to_pay_landlord_legal_fees": 74
+				},
+				"precedent": "AZ-51412066"
+			},
+			{
+				"distance": 2.6543730465072035,
+				"facts": {
+					"landlord_relocation_indemnity_fees": 0,
+					"tenant_dead": false,
+					"tenant_is_bothered": false,
+					"tenant_left_without_paying": false,
+					"tenant_owes_rent": 2460,
+					"tenant_rent_not_paid_more_3_weeks": true
+				},
+				"outcomes": {
+					"additional_indemnity_money": 3620,
+					"landlord_prejudice_justified": true,
+					"orders_expulsion": true,
+					"orders_immediate_execution": true,
+					"orders_resiliation": true,
+					"tenant_ordered_to_pay_landlord": 2460,
+					"tenant_ordered_to_pay_landlord_legal_fees": 81
+				},
+				"precedent": "AZ-51163532"
+			},
+			{
+				"distance": 2.6969256661279988,
+				"facts": {
+					"landlord_relocation_indemnity_fees": 0,
+					"tenant_dead": false,
+					"tenant_is_bothered": false,
+					"tenant_left_without_paying": false,
+					"tenant_owes_rent": 0,
+					"tenant_rent_not_paid_more_3_weeks": true
+				},
+				"outcomes": {
+					"additional_indemnity_money": 2463,
+					"landlord_prejudice_justified": true,
+					"orders_expulsion": true,
+					"orders_immediate_execution": true,
+					"orders_resiliation": true,
+					"tenant_ordered_to_pay_landlord": 2886,
+					"tenant_ordered_to_pay_landlord_legal_fees": 83
+				},
+				"precedent": "AZ-51395624"
+			},
+			{
+				"distance": 2.719885995641093,
+				"facts": {
+					"landlord_relocation_indemnity_fees": 0,
+					"tenant_dead": false,
+					"tenant_is_bothered": false,
+					"tenant_left_without_paying": false,
+					"tenant_owes_rent": 0,
+					"tenant_rent_not_paid_more_3_weeks": true
+				},
+				"outcomes": {
+					"additional_indemnity_money": 3180,
+					"landlord_prejudice_justified": true,
+					"orders_expulsion": true,
+					"orders_immediate_execution": true,
+					"orders_resiliation": true,
+					"tenant_ordered_to_pay_landlord": 3830,
+					"tenant_ordered_to_pay_landlord_legal_fees": 74
+				},
+				"precedent": "AZ-51395655"
+			},
+			{
+				"distance": 2.7806288394504484,
+				"facts": {
+					"landlord_relocation_indemnity_fees": 0,
+					"tenant_dead": false,
+					"tenant_is_bothered": false,
+					"tenant_left_without_paying": false,
+					"tenant_owes_rent": 3600,
+					"tenant_rent_not_paid_more_3_weeks": true
+				},
+				"outcomes": {
+					"additional_indemnity_money": 3750,
+					"landlord_prejudice_justified": true,
+					"orders_expulsion": true,
+					"orders_immediate_execution": true,
+					"orders_resiliation": true,
+					"tenant_ordered_to_pay_landlord": 3600,
+					"tenant_ordered_to_pay_landlord_legal_fees": 78
+				},
+				"precedent": "AZ-51187376"
+			}
+		]
+	}
+}
+```
+
+## Error Response
+
+**Code** : `400 Bad Request`
+
+**Code** : `404 Not Found`
+---
 # Get facts resolved during conversation
 
 Gets only the list of resolved facts for the conversation

--- a/src/backend_service/app.py
+++ b/src/backend_service/app.py
@@ -41,6 +41,14 @@ def get_conversation(conversation_id=None):
         abort(make_response(jsonify(message="Invalid request"), 400))
 
 
+@app.route("/conversation/<conversation_id>/report", methods=['GET'])
+def get_conversation_report(conversation_id=None):
+    if conversation_id:
+        return conversation_controller.get_report(conversation_id)
+    else:
+        abort(make_response(jsonify(message="Invalid request"), 400))
+
+
 @app.route("/conversation/<conversation_id>/resolved", methods=['GET'])
 def get_conversation_resolved_facts(conversation_id=None):
     if conversation_id:

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -93,10 +93,10 @@ def get_report(conversation_id):
     """
 
     conversation = __get_conversation(conversation_id)
-    report = {}
-
     if conversation.report is not None:
         report = json.loads(conversation.report)
+    else:
+        return abort(make_response(jsonify(message="No reports found for this conversation."), 404))
 
     return jsonify(
         {

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -317,12 +317,6 @@ def __ask_initial_question(conversation):
 
     person_type = conversation.person_type
 
-    file_request = None
-    if person_type is PersonType.TENANT:
-        file_request = FileRequest(document_type=DocumentType.LEASE)
-
-    db.session.commit()
-
     # Generate response based on person type
     response = None
     if person_type is PersonType.TENANT:
@@ -330,7 +324,7 @@ def __ask_initial_question(conversation):
     elif person_type is PersonType.LANDLORD:
         response = StaticStrings.chooseFrom(StaticStrings.problem_inquiry_landlord).format(name=conversation.name)
 
-    return {'response_text': response, 'file_request': file_request}
+    return {'response_text': response}
 
 
 def __has_just_accepted_disclaimer(conversation):

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -92,10 +92,15 @@ def get_report(conversation_id):
     :return: JSON report of the conversation
     """
 
-    # conversation = __get_conversation(conversation_id)
+    conversation = __get_conversation(conversation_id)
+    report = {}
+
+    if conversation.report is not None:
+        report = json.loads(conversation.report)
+
     return jsonify(
         {
-            'report': {}
+            'report': report
         }
     )
 

--- a/src/backend_service/controllers/conversation_controller.py
+++ b/src/backend_service/controllers/conversation_controller.py
@@ -85,6 +85,21 @@ def delete_fact_entity(conversation_id, fact_entity_id):
         abort(make_response(jsonify(message="Fact entity does not exist"), 404))
 
 
+def get_report(conversation_id):
+    """
+    Returns a report for the conversation
+    :param conversation_id: ID of the conversation
+    :return: JSON report of the conversation
+    """
+
+    # conversation = __get_conversation(conversation_id)
+    return jsonify(
+        {
+            'report': {}
+        }
+    )
+
+
 def receive_message(conversation_id, message):
     """
     Process an incoming message from the user

--- a/src/backend_service/controllers/conversation_controller_test.py
+++ b/src/backend_service/controllers/conversation_controller_test.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from werkzeug.exceptions import HTTPException
@@ -32,6 +33,30 @@ class ConversationControllerTest(unittest.TestCase):
         with app.test_request_context():
             with self.assertRaises(HTTPException):
                 init_response = conversation_controller.init_conversation("Bob", "bad_person_type")
+
+    def test_get_report(self):
+        with app.test_request_context():
+            conversation = Conversation(name="Bob", person_type=PersonType.TENANT,
+                                        claim_category=ClaimCategory.LEASE_TERMINATION)
+            db.session.add(conversation)
+            db.session.commit()
+
+            report_dict = {'a': 1}
+            conversation.report = json.dumps(report_dict)
+            db.session.commit()
+
+            report = conversation_controller.get_report(conversation.id)
+            self.assertIsNotNone(report)
+
+    def test_get_report_error(self):
+        with app.test_request_context():
+            conversation = Conversation(name="Bob", person_type=PersonType.TENANT,
+                                        claim_category=ClaimCategory.LEASE_TERMINATION)
+            db.session.add(conversation)
+            db.session.commit()
+
+            with self.assertRaises(HTTPException):
+                report = conversation_controller.get_report(conversation.id)
 
     def test_get_fact_entities(self):
         with app.test_request_context():

--- a/src/backend_service/services/static_strings.py
+++ b/src/backend_service/services/static_strings.py
@@ -15,9 +15,9 @@ class StaticStrings:
     ]
 
     problem_inquiry_tenant = [
-        "I see you're a tenant, {name}. If you have it on hand, it would be very helpful if you could upload your lease. What issue can I help you with today?",
-        "What kind of issue are you having as a tenant, {name}? Upload your lease if you have it, it might help in resolving your issues.",
-        "I can help you with all sorts of tenant issues, {name}! Describe your problem to me and upload your lease if available."
+        "I see you're a tenant, {name}. What issue can I help you with today?",
+        "What kind of issue are you having as a tenant, {name}?",
+        "I can help you with all sorts of tenant issues, {name}. Describe your problem to me!"
     ]
 
     @staticmethod

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -1,7 +1,9 @@
+import json
+
 from flask import jsonify, abort, make_response
 
 from nlp_service.rasa.intent_threshold import IntentThreshold
-from nlp_service.services import fact_service
+from nlp_service.services import fact_service, report_service
 from postgresql_db.models import *
 from rasa.rasa_classifier import RasaClassifier
 from services import ml_service
@@ -266,6 +268,13 @@ def __state_giving_prediction(conversation):
         ml_response=ml_response
     )
     similar_precedent_list = ml_response['similar_precedents']
+
+    # Generate a report from the prediction
+    report_dict = report_service.generate_report(
+        conversation=conversation,
+        ml_prediction=ml_prediction,
+        similar_precedents=similar_precedent_list)
+    conversation.report = json.dumps(report_dict)
 
     # Generate statement for prediction
     question = Responses.prediction_statement(

--- a/src/nlp_service/controllers/nlp_controller.py
+++ b/src/nlp_service/controllers/nlp_controller.py
@@ -268,12 +268,14 @@ def __state_giving_prediction(conversation):
         ml_response=ml_response
     )
     similar_precedent_list = ml_response['similar_precedents']
+    probabilities_dict = ml_response['probabilities_vector']
 
     # Generate a report from the prediction
     report_dict = report_service.generate_report(
         conversation=conversation,
         ml_prediction=ml_prediction,
-        similar_precedents=similar_precedent_list)
+        similar_precedents=similar_precedent_list,
+        probabilities_dict=probabilities_dict)
     conversation.report = json.dumps(report_dict)
 
     # Generate statement for prediction

--- a/src/nlp_service/services/ml_service.py
+++ b/src/nlp_service/services/ml_service.py
@@ -19,6 +19,9 @@ outcome_facts = {}
 # Dict containing antifact mappings
 anti_facts = {}
 
+# Dict containing ML statistics
+ml_statistics = {}
+
 
 def get_outcome_facts():
     """
@@ -40,6 +43,17 @@ def get_anti_facts():
         anti_facts = requests.get("{}/{}".format(ML_URL, "antifacts")).json()
 
     return anti_facts
+
+
+def get_statistics():
+    """
+    :return: Dict of antifacts from the ML endpoint.
+    """
+    global ml_statistics
+    if not ml_statistics:
+        ml_statistics = requests.get("{}/{}".format(ML_URL, "statistics")).json()
+
+    return ml_statistics
 
 
 def submit_resolved_fact_list(conversation):

--- a/src/nlp_service/services/report_service.py
+++ b/src/nlp_service/services/report_service.py
@@ -18,10 +18,11 @@ def generate_report(conversation, ml_prediction, similar_precedents):
     # Curves
     report['curves'] = {}
 
-    possible_curve_facts = ml_statistics['regressor']
-    for fact in conversation_facts:
-        if fact in possible_curve_facts:
-            report['curves'][fact] = possible_curve_facts[fact]
+    possible_curve_outcomes = ml_statistics['regressor']
+    for outcome in ml_prediction.keys():
+        if outcome in possible_curve_outcomes:
+            report['curves'][outcome] = dict(possible_curve_outcomes[outcome])
+            report['curves'][outcome]['outcome_value'] = ml_prediction[outcome]
 
     # Outcomes
     report['outcomes'] = dict(ml_prediction)

--- a/src/nlp_service/services/report_service.py
+++ b/src/nlp_service/services/report_service.py
@@ -1,0 +1,40 @@
+from nlp_service.services import ml_service, fact_service
+
+
+def generate_report(conversation, ml_prediction, similar_precedents):
+    report = {}
+    ml_statistics = ml_service.get_statistics()
+    conversation_facts = fact_service.get_resolved_fact_keys(conversation)
+
+    # Prediction accuracy
+    report['accuracy'] = 0
+
+    # Data set size
+    report['data_set'] = ml_statistics['data_set']['size']
+
+    # Similar case count
+    report['similar_case'] = len(similar_precedents)
+
+    # Curves
+    report['curves'] = {}
+
+    possible_curve_facts = ml_statistics['regressor']
+    for fact in conversation_facts:
+        if fact in possible_curve_facts:
+            report['curves'][fact] = possible_curve_facts[fact]
+
+    # Outcomes
+    report['outcomes'] = dict(ml_prediction)
+
+    # Similar Precedents
+    report['similar_precedents'] = []
+
+    # Filter out all facts and outcomes that don't matter from precedents
+    for precedent in similar_precedents:
+        filtered_fact_dict = {k: v for k, v in precedent['facts'].items() if k in conversation_facts}
+        precedent['facts'] = filtered_fact_dict
+        filtered_outcome_dict = {k: v for k, v in precedent['outcomes'].items() if k in ml_prediction}
+        precedent['outcomes'] = filtered_outcome_dict
+        report['similar_precedents'].append(precedent)
+
+    return report

--- a/src/nlp_service/services/report_service.py
+++ b/src/nlp_service/services/report_service.py
@@ -19,13 +19,21 @@ def generate_report(conversation, ml_prediction, similar_precedents):
     report['curves'] = {}
 
     possible_curve_outcomes = ml_statistics['regressor']
-    for outcome in ml_prediction.keys():
+    for outcome in ml_prediction:
         if outcome in possible_curve_outcomes:
             report['curves'][outcome] = dict(possible_curve_outcomes[outcome])
             report['curves'][outcome]['outcome_value'] = ml_prediction[outcome]
 
     # Outcomes
-    report['outcomes'] = dict(ml_prediction)
+    report['outcomes'] = {}
+
+    for outcome in ml_prediction:
+        if int(ml_prediction[outcome]) == 1:
+            report['outcomes'][outcome] = True
+        elif int(ml_prediction[outcome]) == 0:
+            report['outcomes'][outcome] = False
+        else:
+            report['outcomes'][outcome] = ml_prediction[outcome]
 
     # Similar Precedents
     report['similar_precedents'] = []
@@ -33,9 +41,19 @@ def generate_report(conversation, ml_prediction, similar_precedents):
     # Filter out all facts and outcomes that don't matter from precedents
     for precedent in similar_precedents:
         filtered_fact_dict = {k: v for k, v in precedent['facts'].items() if k in conversation_facts}
-        precedent['facts'] = filtered_fact_dict
+        precedent['facts'] = __dict_values_to_int(filtered_fact_dict)
         filtered_outcome_dict = {k: v for k, v in precedent['outcomes'].items() if k in ml_prediction}
-        precedent['outcomes'] = filtered_outcome_dict
+        precedent['outcomes'] = __dict_values_to_int(filtered_outcome_dict)
         report['similar_precedents'].append(precedent)
 
     return report
+
+
+def __dict_values_to_int(dict):
+    for key in dict:
+        if type(dict[key]) is str:
+            try:
+                dict[key] = int(float(dict[key]))
+            except ValueError:
+                pass
+    return dict

--- a/src/nlp_service/services/report_service.py
+++ b/src/nlp_service/services/report_service.py
@@ -4,6 +4,15 @@ from nlp_service.services import ml_service, fact_service
 
 
 def generate_report(conversation, ml_prediction, similar_precedents, probabilities_dict):
+    """
+    Generates a report for a prediction based on ML input
+    :param conversation: The current Conversation
+    :param ml_prediction: A dictionary of outcomes for the conversation received from ml_service
+    :param similar_precedents: A list of dicts containing precedents similar to the current case
+    :param probabilities_dict: A dict of probabilities for every outcome classifier
+    :return: A dict of a report detailing the prediction made by the ml_service
+    """
+
     report = {}
     ml_statistics = ml_service.get_statistics()
     conversation_facts = fact_service.get_resolved_fact_keys(conversation)

--- a/src/nlp_service/services/report_service.py
+++ b/src/nlp_service/services/report_service.py
@@ -1,13 +1,19 @@
+import statistics
+
 from nlp_service.services import ml_service, fact_service
 
 
-def generate_report(conversation, ml_prediction, similar_precedents):
+def generate_report(conversation, ml_prediction, similar_precedents, probabilities_dict):
     report = {}
     ml_statistics = ml_service.get_statistics()
     conversation_facts = fact_service.get_resolved_fact_keys(conversation)
 
     # Prediction accuracy
     report['accuracy'] = 0
+
+    relevant_probabilities_dict = {k: v for k, v in probabilities_dict.items() if k in ml_prediction}
+    accuracy_mean = statistics.mean([float(v) for k, v in relevant_probabilities_dict.items()])
+    report['accuracy'] = accuracy_mean
 
     # Data set size
     report['data_set'] = ml_statistics['data_set']['size']

--- a/src/nlp_service/services/report_service_test.py
+++ b/src/nlp_service/services/report_service_test.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import Mock
+
+from nlp_service.services import ml_service, report_service
+from postgresql_db.models import db, Conversation, PersonType, Fact, FactEntity, ClaimCategory
+
+report_service.ml_service.get_statistics = Mock(return_value={
+    "data_set": {
+        "size": 40000
+    },
+    "regressor": {
+        "additional_indemnity_money": {
+            "mean": 1477.7728467101024,
+            "std": 1927.8147997893939,
+            "variance": 3716469.9022870203
+        },
+        "tenant_pays_landlord": {
+            "mean": 2148.867088064977,
+            "std": 2129.510243010276,
+            "variance": 4534813.8750856845
+        }
+    }
+})
+
+
+class ReportServiceTest(unittest.TestCase):
+    def test_create_report(self):
+        mock_ml_prediction = {
+            "orders_resiliation": 1,
+            "orders_immediate_execution": 1,
+            "additional_indemnity_money": "500.0"
+        }
+        mock_ml_probabilities = {
+            "orders_resiliation": "0.5",
+            "orders_immediate_execution": "0.5",
+            "additional_indemnity_money": "0.5"
+        }
+        mock_ml_similar_precedents = [
+            {
+                "distance": 10.683943352590694,
+                "facts": {
+                    "apartment_dirty": False,
+                    "tenant_owes_rent": "0.0",
+                },
+                "outcomes": {
+                    "additional_indemnity_money": "0.0",
+                    "orders_expulsion": False,
+                    "orders_immediate_execution": False,
+                    "orders_resiliation": False
+                },
+                "precedent": "AZ-1"
+            },
+            {
+                "distance": 11.118096551621953,
+                "facts": {
+                    "apartment_dirty": False,
+                    "tenant_owes_rent": "100.0"
+                },
+                "outcomes": {
+                    "additional_indemnity_money": "50.0",
+                    "orders_expulsion": False,
+                    "orders_immediate_execution": True,
+                    "orders_resiliation": False
+                },
+                "precedent": "AZ-2"
+            }]
+
+        conversation = Conversation(name="Bob", person_type=PersonType.LANDLORD,
+                                    claim_category=ClaimCategory.NONPAYMENT)
+        db.session.add(conversation)
+        db.session.commit()
+
+        fact = Fact.query.filter_by(name="apartment_dirty").first()
+        fact_entity = FactEntity(fact=fact, value="true")
+        conversation.fact_entities.append(fact_entity)
+        db.session.commit()
+
+        report = report_service.generate_report(conversation,
+                                                mock_ml_prediction,
+                                                mock_ml_similar_precedents,
+                                                mock_ml_probabilities)
+
+        # Accuracy
+        self.assertTrue(report['accuracy'] == 0.5)
+
+        # Curves
+        self.assertTrue(report['curves']['additional_indemnity_money']['outcome_value'] == 500)
+
+        # Data Set Size
+        self.assertTrue(report['data_set'] == 40000)
+
+        # Outcomes
+        self.assertTrue("orders_resiliation" in report['outcomes'])
+        self.assertTrue("orders_immediate_execution" in report['outcomes'])
+        self.assertTrue("additional_indemnity_money" in report['outcomes'])
+        self.assertTrue("orders_expulsion" not in report['outcomes'])
+        self.assertTrue(report['outcomes']['orders_resiliation'] == True)
+        self.assertTrue(report['outcomes']['additional_indemnity_money'] == 500)
+        self.assertTrue(report['similar_case'] == 2)
+
+        # Similar Precedents
+        self.assertTrue(len(report['similar_precedents']) == 2)
+        self.assertTrue("apartment_dirty" in report['similar_precedents'][0]["facts"])
+        self.assertTrue("apartment_dirty" in report['similar_precedents'][1]["facts"])
+        self.assertTrue("tenant_owes_rent" not in report['similar_precedents'][1]["facts"])
+        self.assertTrue("tenant_owes_rent" not in report['similar_precedents'][1]["facts"])
+        self.assertTrue("additional_indemnity_money" in report['similar_precedents'][0]["outcomes"])
+        self.assertTrue("additional_indemnity_money" in report['similar_precedents'][1]["outcomes"])
+        self.assertTrue("orders_expulsion" not in report['similar_precedents'][0]["outcomes"])
+        self.assertTrue("orders_expulsion" not in report['similar_precedents'][1]["outcomes"])

--- a/src/nlp_service/services/report_service_test.py
+++ b/src/nlp_service/services/report_service_test.py
@@ -28,7 +28,7 @@ class ReportServiceTest(unittest.TestCase):
         mock_ml_prediction = {
             "orders_resiliation": 1,
             "orders_immediate_execution": 1,
-            "additional_indemnity_money": "500.0"
+            "additional_indemnity_money": 500
         }
         mock_ml_probabilities = {
             "orders_resiliation": "0.5",

--- a/src/postgresql_db/models.py
+++ b/src/postgresql_db/models.py
@@ -79,6 +79,9 @@ class Conversation(db.Model):
     claim_category = db.Column(db.Enum(ClaimCategory))
     bot_state = db.Column(db.Enum(BotState))
 
+    # Documents
+    report = db.Column(db.BLOB)
+
     # One to one
     current_fact_id = db.Column(db.Integer, db.ForeignKey('fact.id'))
     current_fact = db.relationship('Fact', uselist=False, backref='conversation')
@@ -303,4 +306,5 @@ class ConversationSchema(ma.ModelSchema):
     fact_entities = ma.Nested(FactEntitySchema, many=True)
 
     class Meta:
-        model = Conversation
+        fields = (
+        'id', 'name', 'person_type', 'claim_category', 'bot_state', 'current_fact', 'messages', 'fact_entities')

--- a/src/postgresql_db/models.py
+++ b/src/postgresql_db/models.py
@@ -80,7 +80,7 @@ class Conversation(db.Model):
     bot_state = db.Column(db.Enum(BotState))
 
     # Documents
-    report = db.Column(db.BLOB)
+    report = db.Column(db.Text)
 
     # One to one
     current_fact_id = db.Column(db.Integer, db.ForeignKey('fact.id'))


### PR DESCRIPTION
[#43]

- [X] Adds /conversation/:conversation_id/report endpoint to backend service
- [X] Adds report column to Conversation, used to store the generated report as text
- [X] Adds report_service in nlp service which compiles a report each time a prediction is made
- [X] Removes file request for lease from the first question if the person type is tenant

**Note: Requires a DB reset**