### PR TITLE
[#399] Monthly Rent Fact + Bugfix

### DIFF
--- a/src/nlp_service/init_rasa.py
+++ b/src/nlp_service/init_rasa.py
@@ -32,7 +32,6 @@ fact_names = [
     "tenant_individual_responsability",
     "tenant_is_bothered",
     "tenant_lease_fixed",
-    "tenant_monthly_payment",
     "tenant_refuses_retake_apartment",
     "violent",
 ]

--- a/src/nlp_service/rasa/text/fact/individual/tenant_monthly_payment.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_monthly_payment.txt
@@ -8,30 +8,27 @@ i am: im|i'm|i am
 [entity_synonyms]
 
 [common_examples: true]
-($15)
-(15$)
-(100 dollars)
-(one hundred dollars)
+($1500)
+(1500$)
+(650 dollars)
+(eight hundred dollars)
 (three hundred)
-my tenant owes me ($20)
-he owes me (4232.42$)
-he owes me (20 dollars)
-i’m owed (40 dollars) by my tenant
-i’m owed (20 dollars)
-he hasn’t paid me in 3 months and owes me (1853.32$) for rent
-this guy needs to give me back my (5000$)
-he owes me (five hundred dollars)
-(four thousand dollars) are owed to me
-the tenant owes me (four bills)
-he owes me (10 grand)
-he needs to pay me back my (4g)
-the tenant still has to pay me (fifty cents)
-he needs to give me (a hundred dollar bill)
-he is in debt of (two hundred dollar bills)
-the tenant owes me cash money with the sum of (500$)
-damn straight he owes me (100$)
-i’m waiting for him to give me my (twenty dollar bill)
-yeah i’m still waiting for my (8523.24$)
+the monthly rent is ($600)
+i owe (900 dollars) for rent
+the rent is (20 dollars)
+i would say it's about (1853.32$) for rent
+my rent is (5000$)
+it is (five hundred dollars)
+(four thousand dollars) is how much i pay in rent
+only around (six hundred dollars)
+the rental payment is ($900 bucks)
+i pay ($850) per month to live here
+the rent for the tenant is (500$) on a monthly basis
+the rental fee is (1000$) monthly
+to keep this dwelling the monthly payment is ($950) dollars
+rent is ($800) dollars
+we agreed on (five hundred dollars) per month
+rent is easily a cool ($1500) monthly
 
 [common_examples: false]
 negative
@@ -57,14 +54,8 @@ not likely
 fat chance
 no chance in hell
 no he always pays on time
-they pay on time
-i’m not owed any rent
-i’m not owed any money
-he paid everything
-he’s good
-no not yet
-for now he’s still in the clear
-he owes me $0
-he owes me nothing
-he has no debt
-he owes me a grand total of zero dollars
+i don't pay rent monthly
+there is no monthly rent payment
+no payment monthly
+there is none
+i am not sure what the rent payment is

--- a/src/nlp_service/rasa/text/fact/individual/tenant_monthly_payment.txt
+++ b/src/nlp_service/rasa/text/fact/individual/tenant_monthly_payment.txt
@@ -1,0 +1,70 @@
+[meta]
+() = money, ner_duckling
+
+[regex_features]
+gender: (him|he|her|she|they)((')?s)?
+i am: im|i'm|i am
+
+[entity_synonyms]
+
+[common_examples: true]
+($15)
+(15$)
+(100 dollars)
+(one hundred dollars)
+(three hundred)
+my tenant owes me ($20)
+he owes me (4232.42$)
+he owes me (20 dollars)
+i’m owed (40 dollars) by my tenant
+i’m owed (20 dollars)
+he hasn’t paid me in 3 months and owes me (1853.32$) for rent
+this guy needs to give me back my (5000$)
+he owes me (five hundred dollars)
+(four thousand dollars) are owed to me
+the tenant owes me (four bills)
+he owes me (10 grand)
+he needs to pay me back my (4g)
+the tenant still has to pay me (fifty cents)
+he needs to give me (a hundred dollar bill)
+he is in debt of (two hundred dollar bills)
+the tenant owes me cash money with the sum of (500$)
+damn straight he owes me (100$)
+i’m waiting for him to give me my (twenty dollar bill)
+yeah i’m still waiting for my (8523.24$)
+
+[common_examples: false]
+negative
+that is incorrect
+false
+absolutely not
+nope
+no way
+no
+no that's out of the question
+uh-uh
+niet
+nay
+nah
+no absolutely not
+no way jose
+out of the question
+no siree
+no sir
+not on your life
+under no circumstances
+not likely
+fat chance
+no chance in hell
+no he always pays on time
+they pay on time
+i’m not owed any rent
+i’m not owed any money
+he paid everything
+he’s good
+no not yet
+for now he’s still in the clear
+he owes me $0
+he owes me nothing
+he has no debt
+he owes me a grand total of zero dollars

--- a/src/nlp_service/services/ml_service.py
+++ b/src/nlp_service/services/ml_service.py
@@ -119,7 +119,7 @@ def generate_fact_dict(conversation):
                 resolved_facts[fact_entity_name] = True
             elif fact_entity.value == "false":
                 resolved_facts[fact_entity_name] = False
-        elif fact_entity_type == FactType.MONEY:
+        elif fact_entity_type == FactType.MONEY or fact_entity_type == FactType.DURATION_MONTHS:
             resolved_facts[fact_entity_name] = float(fact_entity.value)
 
     ############

--- a/src/nlp_service/services/response_strings.py
+++ b/src/nlp_service/services/response_strings.py
@@ -200,7 +200,7 @@ class Responses:
             ],
         "tenant_monthly_payment":
             [
-                "Is rent owed on a monthly basis for the term of the lease?"
+                "How much is the monthly rent payment?"
             ],
         "tenant_owes_rent":
             [

--- a/src/postgresql_db/models.py
+++ b/src/postgresql_db/models.py
@@ -225,7 +225,7 @@ defined_facts = [
     {'name': 'tenant_is_bothered', 'summary': 'Perte de jouissance', 'type': FactType.BOOLEAN},
     {'name': 'tenant_lease_fixed', 'summary': 'Lease end date stated explicitly', 'type': FactType.BOOLEAN},
     {'name': 'tenant_left_without_paying', 'summary': 'Tenant left without paying', 'type': FactType.BOOLEAN},
-    {'name': 'tenant_monthly_payment', 'summary': 'Requisite monthly rent payment', 'type': FactType.BOOLEAN},
+    {'name': 'tenant_monthly_payment', 'summary': 'Monthly rent payment', 'type': FactType.MONEY},
     {'name': 'tenant_owes_rent', 'summary': 'Tenant owes overdue rent', 'type': FactType.MONEY},
     {'name': 'tenant_refuses_retake_apartment', 'summary': 'Tenant refuses dwelling retake', 'type': FactType.BOOLEAN},
     {'name': 'tenant_rent_not_paid_more_3_weeks', 'summary': 'Rent overdue over 3 weeks', 'type': FactType.BOOLEAN},


### PR DESCRIPTION
[#399]

- [X] Changed type of fact tenant_monthly_payment from BOOLEAN to MONEY
- [X] Added new training data and bot question for tenant_monthly_payment
- [X] Fixed a small bug in nlp service's ml_service wherein it wouldn't send over facts of type DURATION_MONTHS

**Note: Requires DB reset to function properly**