### PR TITLE
Uses proper version of psycopg2 for python to connect to postgresql database…

### DIFF
--- a/src/backend_service/Dockerfile
+++ b/src/backend_service/Dockerfile
@@ -10,8 +10,7 @@ RUN mkdir -p /usr/src/app/src/backend_service
 
 COPY ./src/backend_service/requirements.txt ./src/backend_service/
 COPY ./src/backend_service/requirements_test.txt ./src/backend_service/
-RUN pip install http://initd.org/psycopg/upload/psycopg2-2.7.3.1.dev0/psycopg2-2.7.3.1.dev0-cp36-cp36m-manylinux1_x86_64.whl && \
-    pip install -r ./src/backend_service/requirements_test.txt
+RUN pip install -r ./src/backend_service/requirements_test.txt
 
 COPY . .
 

--- a/src/backend_service/requirements.txt
+++ b/src/backend_service/requirements.txt
@@ -10,3 +10,4 @@ requests==2.18.4
 flask-marshmallow==0.8.0
 marshmallow-sqlalchemy==0.13.1
 marshmallow_enum==1.4.1
+psycopg2==2.7.3.2

--- a/src/nlp_service/Dockerfile
+++ b/src/nlp_service/Dockerfile
@@ -23,8 +23,7 @@ WORKDIR /usr/src/app
 
 COPY ./src/nlp_service/requirements.txt ./src/nlp_service/
 COPY ./src/nlp_service/requirements_test.txt ./src/nlp_service/
-RUN pip install http://initd.org/psycopg/upload/psycopg2-2.7.3.1.dev0/psycopg2-2.7.3.1.dev0-cp36-cp36m-manylinux1_x86_64.whl && \
-    pip install -r ./src/nlp_service/requirements_test.txt
+RUN pip install -r ./src/nlp_service/requirements_test.txt
 
 # Initialize spacy
 RUN python -m spacy download en_core_web_md

--- a/src/nlp_service/requirements.txt
+++ b/src/nlp_service/requirements.txt
@@ -13,6 +13,7 @@ flask-marshmallow==0.8.0
 marshmallow-sqlalchemy==0.13.1
 marshmallow_enum==1.4.1
 joblib==0.11
+psycopg2==2.7.3.2
 
 # Rasa Dependencies
 rasa_nlu==0.11.2


### PR DESCRIPTION
- [x] Uses proper version of psycopg2 for python to connect to postgresql database from PyPA as opposed to a fixed version from GitHub.

Fixes the following error:
```
psycopg2.OperationalError: FATAL:  no pg_hba.conf entry for host "172.18.0.5", user "postgres", database "postgres", SSL off

```